### PR TITLE
cron_jobs_to_schedule

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -702,10 +702,10 @@
                 }
             }
         },
-        "/v1/create-cron-job": {
+        "/v1/create-schedule": {
             "post": {
-                "summary": "Create Cron Job",
-                "operationId": "create_cron_job_v1_create_cron_job_post",
+                "summary": "Create Schedule",
+                "operationId": "create_schedule_v1_create_schedule_post",
                 "security": [
                     {
                         "HTTPBearer": []
@@ -756,10 +756,10 @@
                 }
             }
         },
-        "/v1/update-cron-job/{cron_job_id}": {
+        "/v1/update-schedule/{schedule_id}": {
             "put": {
-                "summary": "Update Cron Job",
-                "operationId": "update_cron_job_v1_update_cron_job__cron_job_id__put",
+                "summary": "Update Schedule",
+                "operationId": "update_schedule_v1_update_schedule__schedule_id__put",
                 "security": [
                     {
                         "HTTPBearer": []
@@ -767,12 +767,12 @@
                 ],
                 "parameters": [
                     {
-                        "name": "cron_job_id",
+                        "name": "schedule_id",
                         "in": "path",
                         "required": true,
                         "schema": {
                             "type": "string",
-                            "title": "Cron Job Id"
+                            "title": "Schedule Id"
                         }
                     },
                     {
@@ -819,10 +819,10 @@
                 }
             }
         },
-        "/v1/delete-cron-job/{cron_job_id}": {
+        "/v1/delete-schedule/{schedule_id}": {
             "delete": {
-                "summary": "Delete Cron Job",
-                "operationId": "delete_cron_job_v1_delete_cron_job__cron_job_id__delete",
+                "summary": "Delete Schedule",
+                "operationId": "delete_schedule_v1_delete_schedule__schedule_id__delete",
                 "security": [
                     {
                         "HTTPBearer": []
@@ -830,12 +830,12 @@
                 ],
                 "parameters": [
                     {
-                        "name": "cron_job_id",
+                        "name": "schedule_id",
                         "in": "path",
                         "required": true,
                         "schema": {
                             "type": "string",
-                            "title": "Cron Job Id"
+                            "title": "Schedule Id"
                         }
                     },
                     {
@@ -9159,10 +9159,10 @@
                         "title": "Id",
                         "description": "The unique identifier for the created cron job."
                     },
-                    "experiment_id": {
+                    "simulation_id": {
                         "type": "string",
-                        "title": "Experiment Id",
-                        "description": "The unique identifier for the associated experiment."
+                        "title": "Simulation Id",
+                        "description": "The unique identifier for the associated simulation."
                     },
                     "cron_expression": {
                         "type": "string",
@@ -9185,7 +9185,7 @@
                 "type": "object",
                 "required": [
                     "id",
-                    "experiment_id",
+                    "simulation_id",
                     "cron_expression"
                 ],
                 "title": "CreateCronJobResponse"
@@ -14147,10 +14147,10 @@
                         "title": "Id",
                         "description": "The unique identifier for the updated cron job."
                     },
-                    "experiment_id": {
+                    "simulation_id": {
                         "type": "string",
-                        "title": "Experiment Id",
-                        "description": "The unique identifier for the associated experiment."
+                        "title": "Simulation Id",
+                        "description": "The unique identifier for the associated simulation."
                     },
                     "cron_expression": {
                         "type": "string",
@@ -14178,7 +14178,7 @@
                 "type": "object",
                 "required": [
                     "id",
-                    "experiment_id",
+                    "simulation_id",
                     "cron_expression",
                     "created_at"
                 ],


### PR DESCRIPTION
associated name changes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renames API endpoints and identifiers in `openapi.json` from cron job to schedule, and experiment_id to simulation_id.
> 
>   - **API Endpoints**:
>     - Rename `/v1/create-cron-job` to `/v1/create-schedule`.
>     - Rename `/v1/update-cron-job/{cron_job_id}` to `/v1/update-schedule/{schedule_id}`.
>     - Rename `/v1/delete-cron-job/{cron_job_id}` to `/v1/delete-schedule/{schedule_id}`.
>   - **Operation IDs and Summaries**:
>     - Update operation IDs and summaries to reflect new endpoint names (e.g., `create_cron_job_v1_create_cron_job_post` to `create_schedule_v1_create_schedule_post`).
>   - **Parameter and Schema Changes**:
>     - Rename `cron_job_id` to `schedule_id` in path parameters.
>     - Rename `experiment_id` to `simulation_id` in response schemas.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=bluejay-ai-dev%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 93d5825e3b782e2574c3fe82106de7dc62e7fdbb. You can [customize](https://app.ellipsis.dev/bluejay-ai-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->