### PR TITLE
Add french to digital human 

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -13121,7 +13121,8 @@
                     "ar",
                     "ru",
                     "zh",
-                    "ml"
+                    "ml",
+                    "fr"
                 ],
                 "title": "LanguageType",
                 "description": "Enum for supported language types"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added French to the Digital Human supported languages by updating the LanguageType enum in the OpenAPI spec. Clients can now use language=fr in requests.

<sup>Written for commit aa2c5fe5639847c3574317c7b6db96c5da7aa21c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add French as a supported language in `openapi.json`.
> 
>   - **API Support**:
>     - Adds "fr" (French) to the list of supported languages in `openapi.json` under `LanguageType` enum.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=bluejay-ai-dev%2Fdocs&utm_source=github&utm_medium=referral)<sup> for aa2c5fe5639847c3574317c7b6db96c5da7aa21c. You can [customize](https://app.ellipsis.dev/bluejay-ai-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->