### PR TITLE
always on API changes

### DIFF
--- a/api-reference/endpoint/add-phone-number.mdx
+++ b/api-reference/endpoint/add-phone-number.mdx
@@ -1,0 +1,7 @@
+---
+title: 'Add Phone Number'
+description: ''
+openapi: 'POST /v1/phone-numbers/add'
+---
+
+Automatically purchases a Twilio phone number for your organization. You can optionally specify a US area code to bias the search (e.g. `415` for San Francisco).

--- a/api-reference/endpoint/phone-numbers.mdx
+++ b/api-reference/endpoint/phone-numbers.mdx
@@ -3,4 +3,5 @@ title: 'Get Phone Numbers'
 description: ''
 openapi: 'GET /v1/phone-numbers'
 ---
-This endpoint allows you to get all phone numbers from your organization
+
+Returns all phone numbers in your organization. Use [Add Phone Number](/api-reference/endpoint/add-phone-number) to provision new Twilio numbers and [Release Phone Number](/api-reference/endpoint/release-phone-number) to release them.

--- a/api-reference/endpoint/release-phone-number.mdx
+++ b/api-reference/endpoint/release-phone-number.mdx
@@ -1,0 +1,7 @@
+---
+title: 'Release Phone Number'
+description: ''
+openapi: 'DELETE /v1/phone-numbers/{phone_number}/release'
+---
+
+Releases a phone number from your organization and Twilio. The phone number will no longer receive calls.

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -671,6 +671,22 @@
                         }
                     },
                     {
+                        "name": "X-Webhook-Secret",
+                        "in": "header",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "X-Webhook-Secret"
+                        }
+                    },
+                    {
                         "name": "X-API-Key",
                         "in": "header",
                         "required": true,
@@ -4431,6 +4447,119 @@
                                         "$ref": "#/components/schemas/PhoneNumberResponse"
                                     },
                                     "title": "Response Get Phone Numbers V1 Phone Numbers Get"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/phone-numbers/add": {
+            "post": {
+                "tags": [
+                    "Phone Number Management"
+                ],
+                "summary": "Add Phone Number",
+                "operationId": "add_phone_number_v1_phone_numbers_add_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "X-API-Key",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "API key required to authenticate requests."
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AddPhoneNumberRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AddPhoneNumberResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/phone-numbers/{phone_number}/release": {
+            "delete": {
+                "tags": [
+                    "Phone Number Management"
+                ],
+                "summary": "Release Phone Number",
+                "operationId": "release_phone_number_v1_phone_numbers__phone_number__release_delete",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "phone_number",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Phone Number"
+                        }
+                    },
+                    {
+                        "name": "X-API-Key",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "API key required to authenticate requests."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ReleasePhoneNumberResponse"
                                 }
                             }
                         }
@@ -9691,6 +9820,66 @@
                 "title": "AddMetricsToLabResponse",
                 "description": "Response model for adding metrics to a lab"
             },
+            "AddPhoneNumberRequest": {
+                "properties": {
+                    "area_code": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Area Code",
+                        "description": "Optional US area code to bias phone number search (e.g. 415)"
+                    }
+                },
+                "type": "object",
+                "title": "AddPhoneNumberRequest",
+                "description": "Request schema for auto-purchasing a Twilio number for an organization."
+            },
+            "AddPhoneNumberResponse": {
+                "properties": {
+                    "phone_number": {
+                        "type": "string",
+                        "title": "Phone Number",
+                        "description": "Purchased E.164 phone number"
+                    },
+                    "twilio_sid": {
+                        "type": "string",
+                        "title": "Twilio Sid",
+                        "description": "Twilio IncomingPhoneNumber SID"
+                    },
+                    "organization_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Organization Id",
+                        "description": "Organization ID"
+                    },
+                    "purchase_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Purchase Date",
+                        "description": "Date when purchased"
+                    },
+                    "price": {
+                        "type": "integer",
+                        "title": "Price",
+                        "description": "Stored price in cents"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "phone_number",
+                    "twilio_sid",
+                    "organization_id",
+                    "purchase_date",
+                    "price"
+                ],
+                "title": "AddPhoneNumberResponse",
+                "description": "Response schema after auto-purchasing and storing a phone number."
+            },
             "AddToCommunityRequest": {
                 "properties": {
                     "digital_human_ids": {
@@ -9722,10 +9911,10 @@
                     "id": {
                         "anyOf": [
                             {
-                                "type": "integer"
+                                "type": "string"
                             },
                             {
-                                "type": "string"
+                                "type": "integer"
                             },
                             {
                                 "type": "null"
@@ -14742,6 +14931,31 @@
                         "title": "Formatted Transcript",
                         "description": "Pre-computed structured transcript as [{role, utterance}]. When provided, skips the format-transcript LLM call."
                     },
+                    "always_on_mode": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Always On Mode",
+                        "description": "Whether always-on mode is enabled",
+                        "default": false
+                    },
+                    "always_on_active": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Always On Active",
+                        "description": "When true, this DH actively receives calls on phone_number. Defaults to True when phone_number is set."
+                    },
                     "num_runs": {
                         "anyOf": [
                             {
@@ -17962,6 +18176,27 @@
                 ],
                 "title": "ReEvaluateSimulationResultResponse"
             },
+            "ReleasePhoneNumberResponse": {
+                "properties": {
+                    "phone_number": {
+                        "type": "string",
+                        "title": "Phone Number",
+                        "description": "Released E.164 phone number"
+                    },
+                    "released": {
+                        "type": "boolean",
+                        "title": "Released",
+                        "description": "Whether the Twilio release was performed"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "phone_number",
+                    "released"
+                ],
+                "title": "ReleasePhoneNumberResponse",
+                "description": "Response schema after releasing a Twilio number."
+            },
             "RemoveConversationsFromLabRequest": {
                 "properties": {
                     "lab_id": {
@@ -18327,6 +18562,17 @@
                             }
                         ],
                         "title": "Pinned"
+                    },
+                    "always_on": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Always On"
                     }
                 },
                 "type": "object",
@@ -18530,6 +18776,19 @@
                         ],
                         "title": "Custom Metrics Passing Threshold",
                         "description": "Score threshold at or above which a custom metric is considered passing (0-100)"
+                    },
+                    "always_on": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Always On",
+                        "description": "When true, simulation has always-on digital humans configured",
+                        "default": false
                     }
                 },
                 "type": "object",
@@ -20354,6 +20613,43 @@
                         ],
                         "title": "Livekit Metadata",
                         "description": "LiveKit-specific configuration and metadata for this digital human. If provided, completely replaces existing metadata."
+                    },
+                    "always_on_mode": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Always On Mode",
+                        "description": "Whether always-on mode is enabled for this digital human"
+                    },
+                    "always_on_active": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Always On Active",
+                        "description": "When true, this DH actively receives calls on phone_number; when false, number is assigned but inactive"
+                    },
+                    "override_conflict": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Override Conflict",
+                        "description": "When true, allows activation to replace an existing always-on active DH using the same phone number.",
+                        "default": false
                     }
                 },
                 "type": "object",
@@ -20575,13 +20871,6 @@
                     "type": {
                         "type": "string",
                         "title": "Error Type"
-                    },
-                    "input": {
-                        "title": "Input"
-                    },
-                    "ctx": {
-                        "type": "object",
-                        "title": "Context"
                     }
                 },
                 "type": "object",

--- a/docs.json
+++ b/docs.json
@@ -238,9 +238,16 @@
             ]
           },
           {
-            "group": "Miscellaneous",
+            "group": "Phone Numbers",
             "pages": [
               "api-reference/endpoint/phone-numbers",
+              "api-reference/endpoint/add-phone-number",
+              "api-reference/endpoint/release-phone-number"
+            ]
+          },
+          {
+            "group": "Miscellaneous",
+            "pages": [
               "api-reference/endpoint/translate-transcript"
             ]
           },

--- a/simulation-integrations/telephony.mdx
+++ b/simulation-integrations/telephony.mdx
@@ -11,7 +11,7 @@ Bluejay makes it incredibly simple to test your voice agents using just a phone 
 
 Testing your voice agent is straightforward:
 
-1. **Add Your Phone Number**: Configure your agent with any valid phone number
+1. **Add Your Phone Number**: Use the [Add Phone Number](/api-reference/endpoint/add-phone-number) API to provision a Twilio number, or configure your agent with any valid phone number
 2. **Create a Simulation**: Set up test scenarios with customer personas
 3. **Run the Test**: Bluejay automatically handles the call setup
 4. **Get Results**: View detailed analytics, transcripts, and recordings
@@ -329,7 +329,7 @@ For customers requiring deeper insights and metadata collection, consider upgrad
 
 ## Getting Started
 
-1. **Configure Your Agent**: Add your phone number to your agent settings
+1. **Configure Your Agent**: Add your phone number to your agent settings (provision numbers via the [Add Phone Number](/api-reference/endpoint/add-phone-number) API or use your own)
 2. **Choose Your Testing Mode**: Select customer service or sales campaign testing
 3. **Create Test Scenarios**: Define customer personas and expected outcomes
 4. **Run Your First Test**: Execute a simulation and monitor results


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds phone number management APIs and “always-on” controls so digital humans can receive inbound calls. Updates docs and OpenAPI to support provisioning, releasing, and activating numbers.

- **New Features**
  - Phone number management: POST `/v1/phone-numbers/add` (auto-purchase Twilio number; optional `area_code`) and DELETE `/v1/phone-numbers/{phone_number}/release`.
  - Always-on controls in API schemas: `always_on_mode`, `always_on_active`, and `override_conflict` for digital humans; `always_on` flags on related models.
  - Optional `X-Webhook-Secret` header support.
  - Docs: new “Phone Numbers” section with Add/Release endpoints; telephony docs now reference the Add Phone Number API.

<sup>Written for commit 0c503ca823233720116688a0ad933556990f9ea4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

