### PR TITLE
update docs for http text tool calls

### DIFF
--- a/api-reference/endpoint/send-http-text-message.mdx
+++ b/api-reference/endpoint/send-http-text-message.mdx
@@ -22,16 +22,37 @@ You are a senior backend engineer integrating the Bluejay API. Think step-by-ste
 | Name | Type | Description |
 |------|------|-------------|
 | X-API-Key | string | API key required to authenticate requests. |
-| message | string | Text message to send |
 | simulation_result_id | string | ID of the simulation result (test result) |
+| message | string | Text message to send (required when `type="message"`) |
+| name | string | Tool name (required when `type="tool_call"`) |
 
-Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpoint/send-http-text-message and include any optional parameters (e.g., `end_conversation`, `end_turn`, `message_id`) that serve your integration's use case and align with Bluejay's testing and monitoring capabilities.
+### Optional Parameters
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| type | string | `"message"` | `"message"` for a conversation turn; `"tool_call"` to log a tool invocation without affecting the transcript |
+| parameters | object | null | Tool input parameters (used when `type="tool_call"`) |
+| output | any | null | Tool return value (used when `type="tool_call"`) |
+| end_conversation | boolean | false | End and evaluate the conversation |
+| end_turn | boolean | true | Process immediately (true) or stack for batching (false) |
+| message_id | string | null | Deduplication key |
 
-### Request Body (required fields)
+Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpoint/send-http-text-message and include any optional parameters that serve your integration's use case and align with Bluejay's testing and monitoring capabilities.
+
+### Request Body examples
 ```json
+// Regular message turn
 {
-  "message": "string",
-  "simulation_result_id": "string"
+  "simulation_result_id": "string",
+  "message": "string"
+}
+
+// Tool call log (does not affect transcript or trigger agent response)
+{
+  "simulation_result_id": "string",
+  "type": "tool_call",
+  "name": "tool_name",
+  "parameters": {},
+  "output": {}
 }
 ```
 

--- a/docs.json
+++ b/docs.json
@@ -284,7 +284,7 @@
       {
         "tab": "API Reference",
         "icon": "code",
-        "openapi": "https://api.getbluejay.ai/openapi.json",
+        "openapi": "https://nerve-skins-improvement-develops.trycloudflare.com/openapi.json",
         "groups": [
           {
             "group": "Overview",

--- a/docs.json
+++ b/docs.json
@@ -284,7 +284,7 @@
       {
         "tab": "API Reference",
         "icon": "code",
-        "openapi": "https://nerve-skins-improvement-develops.trycloudflare.com/openapi.json",
+        "openapi": "https://api.getbluejay.ai/openapi.json",
         "groups": [
           {
             "group": "Overview",

--- a/simulation-integrations/http-webhooks.mdx
+++ b/simulation-integrations/http-webhooks.mdx
@@ -205,11 +205,38 @@ curl -X POST https://api.getbluejay.ai/v1/send-http-text-message \
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `message` | string | Yes | The text message to send |
+| `message` | string | Yes (when `type="message"`) | The text message to send |
 | `simulation_result_id` | string | Yes | ID of the simulation result |
+| `type` | string | No | `"message"` (default) for conversation turns; `"tool_call"` to log a tool call |
 | `end_conversation` | boolean | No | If `true`, ends and evaluates the conversation |
 | `end_turn` | boolean | No | If `true` (default), processes the message immediately; if `false`, stacks it for later |
 | `message_id` | string | No | Unique ID for deduplication |
+| `name` | string | Yes (when `type="tool_call"`) | Name of the tool that was called |
+| `parameters` | object | No | Input parameters passed to the tool |
+| `output` | any | No | Return value or result from the tool |
+
+### Logging Tool Calls Live
+
+If your agent invokes tools during the conversation, you can log them in real time by sending a request with `type="tool_call"`. This records the tool call against the simulation result for evaluation — it does **not** append anything to the conversation transcript or trigger a digital human response.
+
+```bash
+curl -X POST https://api.getbluejay.ai/v1/send-http-text-message \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "simulation_result_id": "13062",
+    "type": "tool_call",
+    "name": "lookup_order",
+    "parameters": {"order_id": "ORD-2024-001"},
+    "output": {"status": "shipped", "tracking_number": "1Z999AA1234567890"}
+}'
+```
+
+Send one request per tool call, as close to when the tool runs as possible. Bluejay will automatically calculate the `start_offset_ms` from the conversation start time.
+
+<Tip>
+  Tool call logs sent via `type="tool_call"` are available for evaluation immediately. You can mix regular messages and tool call logs freely — send them in whichever order they occur in your agent's execution.
+</Tip>
   </Step>
 
   <Step title="Receive Webhook Responses">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Document real-time tool call logging via `type="tool_call"` in `send-http-text-message` and the HTTP webhook guide, with required/optional fields (`name`, `parameters`, `output`, `type` defaults), examples, and behavior notes (no transcript or response, immediate evaluation, auto `start_offset_ms`). Also updates the API Reference OpenAPI URL in `docs.json`.

<sup>Written for commit 8794b513d93a2c697a3a55b96ee358cf4f6ba6d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

