### PR TITLE
contextual silence docs (#175)

### DIFF
--- a/api-reference/endpoint/create-digital-human.mdx
+++ b/api-reference/endpoint/create-digital-human.mdx
@@ -22,7 +22,7 @@ You are a senior backend engineer integrating the Bluejay API. Think step-by-ste
 | Name | Type | Description |
 |------|------|-------------|
 | X-API-Key | string | API key required to authenticate requests. |
-| digital_human | object | Digital human data model for requests (without id and created_at). intent and success_criteria default to empty strings. |
+| digital_human | object | Digital human data model for requests (without id and created_at). intent and success_criteria default to empty strings. `allow_silence_tool` defaults to false; `silence_tool_instructions` defaults to `"default"` (built-in silence-tool behavior). |
 
 Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpoint/create-digital-human and include any optional parameters (e.g., `simulation_ids`, `simulation_id`) that serve your integration's use case and align with Bluejay's testing and monitoring capabilities.
 
@@ -60,6 +60,8 @@ Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpo
       "string"
     ],
     "hangup_instructions": "string",
+    "allow_silence_tool": false,
+    "silence_tool_instructions": "default",
     "silence_timeout": 123,
     "role_description": "string",
     "traits": [

--- a/api-reference/endpoint/create-digital-humans.mdx
+++ b/api-reference/endpoint/create-digital-humans.mdx
@@ -4,4 +4,4 @@ description: ''
 openapi: 'POST /v1/create-digital-humans'
 ---
 
-Bulk create digital humans in a single request. This endpoint batches validation and creation work so large payloads can be processed efficiently, while returning per-item errors for records that fail validation.
+Bulk create digital humans in a single request. This endpoint batches validation and creation work so large payloads can be processed efficiently, while returning per-item errors for records that fail validation. Each item in `digital_humans` accepts the same `digital_human` fields as single create, including **`allow_silence_tool`** (defaults to false if omitted) and **`silence_tool_instructions`** (defaults to `"default"` if omitted).

--- a/api-reference/endpoint/generate-digital-humans.mdx
+++ b/api-reference/endpoint/generate-digital-humans.mdx
@@ -64,3 +64,5 @@ Then implement the integration, export it, and confirm it compiles/passes lint.
 </div>
 
 Given the simulation ID and generation options, this endpoint creates digital humans from scenarios. Payload shape and validation rules (including workflow-based generation) are documented in the OpenAPI schema on this page. For graph-based paths, see [Create workflow](/api-reference/endpoint/create-workflow) and the [Workflows cookbook](/cookbook/workflows).
+
+The generate request does not accept `allow_silence_tool` or `silence_tool_instructions`; those are set when you create or update a digital human explicitly. Generated or returned `digital_human` objects in responses may still include those fields at model defaults (`allow_silence_tool` false, `silence_tool_instructions` `"default"`). Whether the silence tool runs in voice simulations is determined by the execution layer that reads stored test-case data, not by this API alone.

--- a/api-reference/endpoint/get-digital-human.mdx
+++ b/api-reference/endpoint/get-digital-human.mdx
@@ -52,4 +52,4 @@ Then implement the integration, export it, and confirm it compiles/passes lint.
 </div>
 
 
-This endpoint allows you to update an existing digital human. Provide the digital human ID and updated details to update the metric.
+This endpoint returns a digital human by ID, including `allow_silence_tool` and `silence_tool_instructions` when present in the stored record.

--- a/api-reference/endpoint/update-digital-human.mdx
+++ b/api-reference/endpoint/update-digital-human.mdx
@@ -12,7 +12,7 @@ You are a senior backend engineer integrating the Bluejay API. Think step-by-ste
 
 ## Update Digital Human — PUT /v1/update-digital-human/{digital_human_id}
 
-> **What this endpoint does:** Update a digital human by ID. Returns 404 if the digital human does not exist or belongs to a different organization. **Effective tag:** If the body includes `tag`, workflow rules use that tag; otherwise they use existing stored tags. **Workflow-tagged (tag lowercased contains `workflow`):** **400** if intent, success_criteria, role_description, original_transcript, or formatted_transcript **change** from stored values. Same values as DB (idempotent full PUT) are OK. `enriched_playback` remains updatable. **Transcript update behavior (three cases):** - `original_transcript` only: the middleware calls an LLM formatter to produce `formatted_transcript`; both are stored. - Both `original_transcript` and `formatted_transcript`: LLM formatting is skipped; both values are stored as-is and intent/description is derived from the formatted transcript. - `formatted_transcript` only: LLM formatting is skipped; `formatted_transcript` is stored, `original_transcript` is set to null in the DB, and intent/description is derived from the formatted transcript. See docs: Workflow tags & enriched playback.
+> **What this endpoint does:** Update a digital human by ID. Returns 404 if the digital human does not exist or belongs to a different organization. Body fields are patch-style: omit a field to leave it unchanged; include `allow_silence_tool` and/or `silence_tool_instructions` to update them (use the string `"default"` for built-in silence-tool behavior). **Effective tag:** If the body includes `tag`, workflow rules use that tag; otherwise they use existing stored tags. **Workflow-tagged (tag lowercased contains `workflow`):** **400** if intent, success_criteria, role_description, original_transcript, or formatted_transcript **change** from stored values. Same values as DB (idempotent full PUT) are OK. `enriched_playback` remains updatable. **Transcript update behavior (three cases):** - `original_transcript` only: the middleware calls an LLM formatter to produce `formatted_transcript`; both are stored. - Both `original_transcript` and `formatted_transcript`: LLM formatting is skipped; both values are stored as-is and intent/description is derived from the formatted transcript. - `formatted_transcript` only: LLM formatting is skipped; `formatted_transcript` is stored, `original_transcript` is set to null in the DB, and intent/description is derived from the formatted transcript. See docs: Workflow tags & enriched playback.
 
 **Endpoint:** PUT `https://api.getbluejay.ai/v1/update-digital-human/{digital_human_id}`
 **Auth:** `X-API-Key` header
@@ -59,6 +59,8 @@ Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpo
     "string"
   ],
   "hangup_instructions": "string",
+  "allow_silence_tool": false,
+  "silence_tool_instructions": "default",
   "silence_timeout": 123,
   "simulation_ids": [
     123

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -15694,6 +15694,18 @@
             "title": "Hangup Instructions",
             "description": "Freeform instructions for how/when to hang up"
           },
+          "allow_silence_tool": {
+            "type": "boolean",
+            "title": "Allow Silence Tool",
+            "description": "Allow the digital human to use the silence tool",
+            "default": false
+          },
+          "silence_tool_instructions": {
+            "type": "string",
+            "title": "Silence Tool Instructions",
+            "description": "Tool instructions; use \"default\" for built-in behavior or custom text",
+            "default": "default"
+          },
           "silence_timeout": {
             "anyOf": [
               {
@@ -16151,6 +16163,32 @@
             ],
             "title": "Hangup Instructions",
             "description": "Freeform instructions for how/when to hang up"
+          },
+          "allow_silence_tool": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allow Silence Tool",
+            "description": "Allow the digital human to use the silence tool",
+            "default": false
+          },
+          "silence_tool_instructions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Silence Tool Instructions",
+            "description": "Tool instructions; \"default\" for built-in behavior or a custom string.",
+            "default": "default"
           },
           "silence_timeout": {
             "anyOf": [
@@ -21770,6 +21808,32 @@
             ],
             "title": "Hangup Instructions",
             "description": "Freeform instructions for how/when to hang up"
+          },
+          "allow_silence_tool": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allow Silence Tool",
+            "description": "Allow the digital human to use the silence tool",
+            "default": null
+          },
+          "silence_tool_instructions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Silence Tool Instructions",
+            "description": "Tool instructions; set to \"default\" for built-in behavior or custom text",
+            "default": null
           },
           "silence_timeout": {
             "anyOf": [

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,14 @@ icon: clock
 rss: true
 ---
 
+<Update label="April 14th, 2026" tags={["Improvement", "API"]}>
+  ## Digital Human: silence tool fields
+
+  Digital human create, read, update, delete, and bulk APIs now expose **`allow_silence_tool`** and **`silence_tool_instructions`**, aligned with how **`allow_end_call_tool`** and **`hangup_instructions`** are stored and returned. Create and bulk-create default to `allow_silence_tool: false` and `silence_tool_instructions: "default"` when omitted; updates treat fields as optional (omit to leave unchanged). OpenAPI schemas **`DigitalHumanRequestData`**, **`DigitalHumanResponseData`**, and **`UpdateDigitalHumanRequest`** include the new properties.
+
+  [Create digital human](/api-reference/endpoint/create-digital-human) · [Update digital human](/api-reference/endpoint/update-digital-human)
+</Update>
+
 <Update label="April 3rd, 2026" tags={["Improvement", "API"]}>
   ## Redesigned Workflows
 

--- a/core-concepts/digital-humans.mdx
+++ b/core-concepts/digital-humans.mdx
@@ -29,6 +29,8 @@ Every Digital Human is defined by the following fields:
 | **Scripted Responses** | Map | Trigger-response pairs for deterministic behavior |
 | **DTMF Sequences** | List | Touch-tone codes to send during the call |
 | **Silence Duration** | Number | Seconds the Digital Human stays silent at a specified point |
+| **Allow silence tool** | Boolean | When true, the voice runtime may use the silence tool for this digital human (subject to execution-layer rules) |
+| **Silence tool instructions** | String | Use `"default"` for built-in silence-tool behavior; otherwise custom instructions for the runtime. Distinct from scripted silence duration above |
 
 ## How Bluejay Generates Digital Humans
 

--- a/key-concepts/digital-humans/configuration.mdx
+++ b/key-concepts/digital-humans/configuration.mdx
@@ -86,6 +86,8 @@ Trigger: After the agent says "Please enter your account number followed by the 
 
 Configure a Digital Human to **stay silent** for a specified duration. This tests how your agent handles dead air -- does it re-prompt the customer? Does it escalate? Does it hang up too early?
 
+Separately, the API stores **`allow_silence_tool`** (boolean) and **`silence_tool_instructions`** (string) on each digital human. When `allow_silence_tool` is true, the voice runtime *may* use a silence tool according to its own rules. Use the literal string `"default"` for instructions to mean “built-in product behavior”; any other non-empty string is custom guidance for that runtime. Ending a call is analogous but not identical: **`allow_end_call_tool`** plus optional **`hangup_instructions`** (often null when you do not want custom hangup copy). Whether the silence tool actually runs is enforced in the simulation execution layer, not in the API middleware alone.
+
 ### IVR System Simulation
 
 Digital Humans can **simulate an IVR (Interactive Voice Response) system** so your agent can navigate through it. This is the inverse of the typical setup -- instead of a human calling your agent, your agent is calling into a phone tree, and the Digital Human plays the role of that phone tree.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documented and exposed Digital Human silence tool fields across the API and docs. Added `allow_silence_tool` and `silence_tool_instructions` with clear defaults and update behavior, and updated OpenAPI schemas.

- **New Features**
  - Create and bulk-create accept `allow_silence_tool` (defaults to false) and `silence_tool_instructions` (defaults to "default"); update supports patch-style changes for these fields; get returns them when stored.
  - Generate endpoint does not accept these fields; responses may include them at model defaults, and actual silence-tool use is decided by the execution layer.
  - OpenAPI updated (`DigitalHumanRequestData`, `DigitalHumanResponseData`, `UpdateDigitalHumanRequest`), plus core concepts/configuration docs and changelog.

<sup>Written for commit eda8e82e3f980ba18a3df6ec0342b3fa5cde98ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

