### PR TITLE
rewrite ws protocol

### DIFF
--- a/chirp_rewrite.md
+++ b/chirp_rewrite.md
@@ -1,0 +1,590 @@
+---
+name: chirp-v2-redesign
+overview: Rewrite CHIRP as a transport-only protocol. Bluejay is the WS client; the customer runs a WS server. Audio is 16 kHz mono PCM in WebSocket binary frames. No format negotiation, no base64, no VAD in the translator. Speech events from us are derived from LiveKit agent events. All customer-sent text messages are optional; the minimum integration is "accept connection, stream PCM, receive PCM."
+todos:
+  - id: confirm-design
+    content: Get sign-off on the redesigned CHIRP spec
+    status: pending
+  - id: message-types
+    content: Replace src/models/chirp_message.py with the slim envelope and three message types (speech.started, speech.completed, session.error). Drop MessageType.STATUS, MessageType.CONTROL, audio constructors, sender/metadata fields.
+    status: pending
+  - id: frame-split
+    content: Split text vs binary receive handling in customer_integrations/translator.py. Binary frames go to a raw audio handler, text frames go to a JSON event handler. Drop the AudioMixer integration.
+    status: pending
+  - id: translator-rewrite
+    content: Rewrite customer_integrations/default_translator.py as a pure transport. Delete all WAV parsing, format sniffing, base64 audio, silence detection, amplitude/RMS checks, buffering, and silence injection. Add 16k<->48k resampling at the boundary. Net delete ~500 lines.
+    status: pending
+  - id: subclass-adaptation
+    content: Update customer_integrations/bubba.py to match the new translator API (it currently overrides connect_to_customer and send_to_customer to inject a config message at connect)
+    status: pending
+  - id: livekit-event-bridge
+    content: Hook LiveKit agent speech-start and speech-finish events to emit speech.started / speech.completed text frames with server-minted utterance_ids
+    status: pending
+  - id: customer-interrupt
+    content: When customer sends speech.started during an in-flight agent utterance, call LiveKit agent interrupt API and emit speech.completed for the canceled utterance
+    status: pending
+  - id: error-handling
+    content: Implement the error policy (session.error responder, recoverable vs fatal classification, test_result status mapping including REJECTED for auth and INCOMPLETED for fatals)
+    status: pending
+  - id: drop-deps
+    content: Remove ffmpeg-python from requirements.txt and any imports that no longer have callers after the rewrite
+    status: pending
+  - id: test-server-rewrite
+    content: Rewrite tests/websocket_server.py to speak the new wire protocol (binary PCM both ways, optional text events). Keep --require-auth and -l/-r features. Acts as a stand-in for what a customer would build.
+    status: pending
+  - id: spec-doc
+    content: Write the one-page customer-facing CHIRP spec doc emphasizing the zero-JSON minimum integration
+    status: pending
+isProject: false
+---
+
+# CHIRP Rewrite: A Transport-Only Voice Protocol
+
+## Roles
+
+
+| Role             | Who           | Implements                                                                 |
+| ---------------- | ------------- | -------------------------------------------------------------------------- |
+| WebSocket client | Bluejay agent | `websockets.connect()`, sends `Authorization: Basic` header during upgrade |
+| WebSocket server | Customer      | Accepts connections, validates auth, exchanges binary + text frames        |
+
+
+The customer must stand up a WebSocket server endpoint (e.g., `wss://customer.example.com/voice`). They are responsible for:
+
+- Accepting our `Authorization: Basic` header during the HTTP upgrade and returning HTTP 101 (or HTTP 401 to reject)
+- Exchanging binary PCM frames in both directions during the session
+- Optionally sending text events for finer control
+
+In the rest of this doc, "we" / "Bluejay" = WS client, "customer" = WS server.
+
+---
+
+## Guiding principles
+
+- **One wire format. No negotiation.** 16 kHz mono `pcm_s16le`. Period.
+- **Right WebSocket frame type.** Binary for audio, text/JSON for events.
+- **The protocol is a transport, not a brain.** VAD, turn-taking, and speech detection belong in the LiveKit voice agent. The translator just shuttles bytes.
+- **All customer text messages are optional.** Minimum integration is "accept WS, stream binary, receive binary."
+- **Our outbound speech events are derived from LiveKit agent events**, not from heuristics on the audio itself.
+- **Hard rewrite, no compatibility shim.** Old CHIRP code is deleted. Existing customers migrate to the new spec.
+
+---
+
+## Wire format (locked)
+
+
+| Property         | Value                                            | Why                                                                               |
+| ---------------- | ------------------------------------------------ | --------------------------------------------------------------------------------- |
+| Encoding         | `pcm_s16le`                                      | Universally supported, no decoding cost                                           |
+| Sample rate      | **16000 Hz**                                     | Speech-AI industry standard; matches telephony wideband; matches every STT engine |
+| Channels         | **1 (mono)**                                     | Voice is mono                                                                     |
+| Frame size       | recommended 20 ms (640 bytes), any size accepted | 20 ms is the telephony / WebRTC standard; we don't enforce                        |
+| Audio frame type | WebSocket `binary`                               | No envelope, no encoding overhead                                                 |
+| Event frame type | WebSocket `text` (UTF-8 JSON)                    | Standard JSON parsing                                                             |
+
+
+We resample 16k -> 48k on inbound and 48k -> 16k on outbound at the WebSocket boundary so LiveKit's pipeline (which is 48 kHz natively) is unchanged. Resampling cost is negligible.
+
+---
+
+## Audio direction
+
+
+| Direction                             | What it carries                                        |
+| ------------------------------------- | ------------------------------------------------------ |
+| Customer (server) -> Bluejay (client) | User microphone audio (so the agent can hear)          |
+| Bluejay (client) -> Customer (server) | Agent TTS audio (so the customer can play to the user) |
+
+
+---
+
+## Lowest-lift customer integration (the entire spec for them)
+
+```text
+1. Stand up a WebSocket server at wss://your-host/<path>
+2. On incoming connection, validate Authorization: Basic <base64(user:pass)> header.
+   Reject with HTTP 401 if invalid; accept with HTTP 101 if valid.
+3. From then on:
+     - Whenever you have user audio, send it as a WS binary frame
+       (raw 16k mono int16le PCM, any size).
+     - Whenever you receive a binary frame, play it as raw 16k mono int16le PCM
+       (this is the agent's voice).
+     - Optionally: ignore any text frames you receive (they're just for UI hints).
+4. Close the WebSocket to hang up.
+```
+
+In a Python `websockets` server, this is roughly:
+
+```python
+async def handler(ws):
+    if not check_basic_auth(ws.request.headers.get("Authorization")):
+        await ws.close(1008)
+        return
+    asyncio.create_task(forward_mic_to(ws))           # send binary out
+    async for msg in ws:
+        if isinstance(msg, bytes):
+            speaker.play(msg)                          # raw PCM in
+        # else: text frame; safe to ignore
+```
+
+**Zero JSON messages required from the customer.** Zero state to maintain.
+
+---
+
+## Advanced integration (opt-in)
+
+Customers with their own VAD or push-to-talk source can send speech events for tighter latency. We respect them when sent:
+
+
+| Customer sends                              | Our behavior                                                                                                                                         |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `speech.started` while we are mid-utterance | We immediately stop sending agent audio, call LiveKit's agent interrupt API, emit `speech.completed` for the canceled utterance, switch to listening |
+| `speech.started` when we are idle           | Informational; logged. LiveKit's VAD will trigger the agent off the audio anyway                                                                     |
+| `speech.completed`                          | Informational; can shave VAD-tail-padding latency by signaling end-of-turn explicitly                                                                |
+
+
+There is no separate `interrupt` message. Sending `speech.started` while we are speaking *is* the interrupt.
+
+---
+
+## Protocol reference (the full wire vocabulary)
+
+The entire protocol consists of **four message kinds** exchanged over the WebSocket. Everything else is implied.
+
+### Summary table
+
+
+| Kind               | WS frame type | Bluejay -> Customer                                       | Customer -> Bluejay                                                       |
+| ------------------ | ------------- | --------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Audio              | `binary`      | **Required** whenever agent is speaking                   | Required to get anything done (else user can't be heard), but not policed |
+| `speech.started`   | `text` JSON   | **Automatic**, sent by us when LiveKit agent starts TTS   | **Optional.** If sent, acts as interrupt if agent is mid-utterance        |
+| `speech.completed` | `text` JSON   | **Automatic**, sent by us when LiveKit agent finishes TTS | **Optional.** Informational end-of-turn hint                              |
+| `session.error`    | `text` JSON   | Sent by us on customer's protocol violation               | Sent by customer on our protocol violation, or server-side trouble        |
+
+
+A minimum-integration customer can choose to send only `binary` frames and receive only `binary` frames. They never have to parse or emit any JSON.
+
+---
+
+### Text envelope (common shape for all text frames)
+
+```json
+{
+  "type":  "<message type>",
+  "id":    "<uuid string>",
+  "ts_ms": 1729123456789,
+  "data":  { /* type-specific fields */ }
+}
+```
+
+- `type`: one of `speech.started`, `speech.completed`, `session.error`. Required.
+- `id`: UUID. Required on the wire. Auto-filled by us on receive if missing.
+- `ts_ms`: Unix milliseconds integer. Required on the wire. Auto-filled on receive.
+- `data`: type-specific payload object. Required (may be `{}` if the type has no fields, though none of our types are currently field-less).
+
+---
+
+### Message 1 — Binary audio frame
+
+- **WS frame type**: `binary`
+- **Both directions.**
+- **Required**: yes, this is the actual audio.
+- **Shape**: raw bytes. Interpreted as 16 kHz mono signed 16-bit little-endian PCM samples. Any byte length accepted (just must be even, since samples are 2 bytes).
+- **Semantics**:
+  - Customer -> Bluejay: user microphone audio. Gets resampled to 48 kHz and pushed into LiveKit's `AudioSource`.
+  - Bluejay -> Customer: agent TTS audio. Delivered as LiveKit produces it, resampled to 16 kHz.
+- **No metadata.** No headers. No JSON envelope. Just samples.
+
+---
+
+### Message 2 — `speech.started`
+
+- **WS frame type**: `text`
+- **Both directions, different meanings.**
+- **Required**: never required from customer; always emitted by us when the agent starts talking.
+- **Shape**:
+
+```json
+  {
+    "type": "speech.started",
+    "id":   "uuid",
+    "ts_ms": 1729123456789,
+    "data": { "utterance_id": "u_abc123" }
+  }
+  
+
+```
+
+- **Required fields inside `data`**: `utterance_id` (string).
+- **Semantics**:
+  - **Bluejay -> Customer**: "The agent just started speaking. The binary frames that follow are this utterance's audio until you see `speech.completed` with the same `utterance_id`." Emitted automatically based on LiveKit's `agent_speech_started` event.
+  - **Customer -> Bluejay**: "I'm about to start sending user audio for a new turn." Behavior depends on state:
+    - If agent is currently mid-utterance -> we **interrupt** the agent (call LiveKit's interrupt API), emit `speech.completed` for the canceled utterance, and switch to listening.
+    - If agent is idle -> informational. LiveKit's VAD will detect speech from the binary frames anyway.
+
+---
+
+### Message 3 — `speech.completed`
+
+- **WS frame type**: `text`
+- **Both directions, different meanings.**
+- **Required**: never required from customer; always emitted by us when the agent stops talking.
+- **Shape**:
+
+```json
+  {
+    "type": "speech.completed",
+    "id":   "uuid",
+    "ts_ms": 1729123456789,
+    "data": { "utterance_id": "u_abc123" }
+  }
+  
+
+```
+
+- **Required fields inside `data`**: `utterance_id` (string, must match a prior `speech.started`).
+- **Semantics**:
+  - **Bluejay -> Customer**: "The agent finished this utterance. No more binary frames for `utterance_id` are coming." Emitted on LiveKit's `agent_speech_finished` event (or on interrupt).
+  - **Customer -> Bluejay**: "I'm done sending user audio for this turn." Informational; can let LiveKit skip the VAD tail-padding wait and respond slightly faster. Unknown `utterance_id` is logged and ignored.
+
+---
+
+### Message 4 — `session.error`
+
+- **WS frame type**: `text`
+- **Both directions.**
+- **Required**: never required, but strongly recommended (helps the other side debug).
+- **Shape**:
+
+```json
+  {
+    "type": "session.error",
+    "id":   "uuid",
+    "ts_ms": 1729123456789,
+    "data": {
+      "code":    "INVALID_MESSAGE",
+      "message": "Unexpected type 'foo'; expected one of: speech.started, speech.completed, session.error"
+    }
+  }
+  
+
+```
+
+- **Required fields inside `data`**: `code` (one of the closed-enum values below), `message` (human-readable string).
+- **Closed enum for `code`**:
+
+  | Code                  | Meaning                                                                                                                                                   |
+  | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | `AUTH_FAILED`         | Customer's server rejected our handshake (actually delivered as HTTP 401 before upgrade, never as a `session.error` frame — listed here for completeness) |
+  | `INVALID_MESSAGE`     | Malformed JSON or unknown `type`                                                                                                                          |
+  | `MISSING_FIELD`       | Required field absent from a known message type                                                                                                           |
+  | `INVALID_AUDIO_FRAME` | Binary frame is empty or has odd byte length                                                                                                              |
+  | `INTERNAL_ERROR`      | Bug on the sender's side; sender will close the connection after sending                                                                                  |
+
+- **Semantics**:
+  - **Bluejay -> Customer**: we detected a protocol violation from the customer. Usually recoverable — we drop the offending message and keep the connection open. `INTERNAL_ERROR` means we're about to close.
+  - **Customer -> Bluejay**: we log it at ERROR level, surface it in `test_result.metadata` for later debugging, and keep the connection open (unless customer also closes the WS).
+
+---
+
+### utterance_id
+
+A free-form string (UUID, timestamp, counter — anything unique within the session). Used to match `speech.started` to its `speech.completed`. Server-minted for events we send. Customer mints their own for events they send. Customers using the minimum integration never see or generate one.
+
+---
+
+## Complete sample flow
+
+Illustrates every message kind in one session, covering the minimum integration, optional customer events, barge-in, and an error.
+
+```text
+# 1. WebSocket handshake
+[Bluejay -> Customer] GET /voice HTTP/1.1
+                      Authorization: Basic dG9tYXM6dG9tYXM=
+                      Connection: Upgrade
+                      Upgrade: websocket
+                      Sec-WebSocket-Version: 13
+[Customer -> Bluejay] HTTP/1.1 101 Switching Protocols
+
+# 2. User starts talking (minimum integration path — no speech.started from customer)
+[Customer -> Bluejay] binary <640 bytes: 20 ms of user mic @ 16k mono int16le>
+[Customer -> Bluejay] binary <640 bytes>
+[Customer -> Bluejay] binary <640 bytes>
+[Customer -> Bluejay] binary <640 bytes>
+[Customer -> Bluejay] binary <640 bytes>   # user pauses here; LiveKit VAD fires
+
+# 3. LiveKit voice agent responds. We emit speech events + binary.
+[Bluejay -> Customer] text {
+                        "type": "speech.started",
+                        "id": "b1-evt-0001",
+                        "ts_ms": 1729123458012,
+                        "data": { "utterance_id": "agent-u1" }
+                      }
+[Bluejay -> Customer] binary <640 bytes: 20 ms of agent TTS>
+[Bluejay -> Customer] binary <640 bytes>
+[Bluejay -> Customer] binary <640 bytes>
+[Bluejay -> Customer] binary <640 bytes>
+[Bluejay -> Customer] text {
+                        "type": "speech.completed",
+                        "id": "b1-evt-0002",
+                        "ts_ms": 1729123460220,
+                        "data": { "utterance_id": "agent-u1" }
+                      }
+
+# 4. Agent starts talking again, but this time customer (advanced) barges in.
+[Bluejay -> Customer] text { "type": "speech.started",
+                             "data": { "utterance_id": "agent-u2" }, ... }
+[Bluejay -> Customer] binary <640 bytes>
+[Bluejay -> Customer] binary <640 bytes>
+
+# Customer's own VAD detects user talking over the agent
+[Customer -> Bluejay] text {
+                        "type": "speech.started",
+                        "id": "cust-evt-0010",
+                        "ts_ms": 1729123461500,
+                        "data": { "utterance_id": "user-u1" }
+                      }
+
+# We interrupt LiveKit agent and close out the canceled utterance
+[Bluejay -> Customer] text { "type": "speech.completed",
+                             "data": { "utterance_id": "agent-u2" }, ... }
+
+# Customer streams user audio
+[Customer -> Bluejay] binary <640 bytes>
+[Customer -> Bluejay] binary <640 bytes>
+[Customer -> Bluejay] text {
+                        "type": "speech.completed",
+                        "data": { "utterance_id": "user-u1" }, ...
+                      }
+
+# 5. Customer accidentally sends a bad message
+[Customer -> Bluejay] text { "type": "speech.started", "data": {} }   # missing utterance_id
+[Bluejay -> Customer] text {
+                        "type": "session.error",
+                        "id": "b1-err-0001",
+                        "ts_ms": 1729123462000,
+                        "data": {
+                          "code": "MISSING_FIELD",
+                          "message": "speech.started requires data.utterance_id"
+                        }
+                      }
+# Connection stays open. Customer can fix and retry.
+
+# 6. Call ends normally
+[Customer -> Bluejay] WS close 1000 "call ended"
+```
+
+---
+
+## Error handling
+
+### Connection-establishment errors (we are connecting out)
+
+
+| Scenario                                        | Behavior                                                        |
+| ----------------------------------------------- | --------------------------------------------------------------- |
+| HTTP 401/403 from customer's server             | Raise `WebSocketAuthError`, set `test_result.status = REJECTED` |
+| Customer host unreachable / TCP refused         | Retry 3x with backoff. After exhaustion, set `INCOMPLETED`      |
+| TLS handshake failure (`wss://` cert issues)    | Same retry policy, then `INCOMPLETED`                           |
+| Customer accepts upgrade but immediately closes | `INCOMPLETED`, log close code/reason                            |
+
+
+### Mid-session errors we detect (customer sent us something invalid)
+
+
+| Scenario                                              | Severity    | Behavior                                                                                      |
+| ----------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------- |
+| Malformed JSON in a text frame                        | Recoverable | Send `session.error { code: INVALID_MESSAGE }`, drop the frame, keep going                    |
+| Unknown `type` value                                  | Recoverable | Send `session.error { code: INVALID_MESSAGE }`, drop the frame (forward-compat for new types) |
+| `speech.started` missing `data.utterance_id`          | Recoverable | Send `session.error { code: MISSING_FIELD }`, drop                                            |
+| `speech.completed` for an unknown utterance_id        | Recoverable | Log warning, ignore                                                                           |
+| Binary frame with odd byte length (not int16-aligned) | Recoverable | Send `session.error { code: INVALID_AUDIO_FRAME }`, drop                                      |
+| Customer closes the WS gracefully                     | Normal end  | Tear down LiveKit session; status based on call completion                                    |
+| Customer's WS dies (network drop, server crash)       | Fatal       | Catch `ConnectionClosed`, set `INCOMPLETED`, end LiveKit session                              |
+
+
+### Mid-session errors customer sends us
+
+If the customer sends us `session.error`, we log it at ERROR level with their code+message and surface it in `test_result.metadata` for debugging. We do not close the connection unless they also close it.
+
+### Closed enum: error codes
+
+
+| Code                  | When                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| `AUTH_FAILED`         | Customer's server rejects our handshake (delivered as HTTP 401, not as session.error) |
+| `INVALID_MESSAGE`     | Malformed JSON or unknown `type`                                                      |
+| `MISSING_FIELD`       | Required field absent from a known message type                                       |
+| `INVALID_AUDIO_FRAME` | Binary frame is empty or odd-byte-length                                              |
+| `INTERNAL_ERROR`      | Bug on our side; we close the connection after sending                                |
+
+
+### `session.error` shape
+
+```json
+{
+  "type": "session.error",
+  "id":   "uuid",
+  "ts_ms": 1729123456789,
+  "data": {
+    "code": "INVALID_MESSAGE",
+    "message": "Unexpected type 'foo'; expected one of: speech.started, speech.completed, session.error"
+  }
+}
+```
+
+`code` is from the closed enum (machine-readable, programmatically branched on). `message` is human-readable for debugging.
+
+### WebSocket close codes when we close
+
+- `1000` Normal closure (call ended)
+- `1011` Internal error (LiveKit blew up, our bug)
+
+---
+
+## Wire flow
+
+### Minimum-integration customer
+
+```mermaid
+sequenceDiagram
+    participant B as Bluejay (WS client)
+    participant C as Customer (WS server)
+
+    B->>C: WS upgrade (Authorization Basic ...)
+    C-->>B: HTTP 101
+
+    Note over C: User speaks into mic
+    C->>B: binary <pcm 20ms>
+    C->>B: binary <pcm 20ms>
+    C->>B: binary <pcm 20ms>
+
+    Note over B: LiveKit VAD triggers agent
+    B->>C: text { type speech.started, data { utterance_id u1 } }
+    B->>C: binary <pcm 20ms>
+    B->>C: binary <pcm 20ms>
+    B->>C: text { type speech.completed, data { utterance_id u1 } }
+
+    C->>B: WS close 1000
+```
+
+
+
+### Advanced customer with explicit barge-in
+
+```mermaid
+sequenceDiagram
+    participant B as Bluejay (WS client)
+    participant C as Customer (WS server)
+
+    B->>C: text { type speech.started, data { utterance_id u1 } }
+    B->>C: binary <pcm 20ms>
+    B->>C: binary <pcm 20ms>
+
+    Note over C: Customer VAD detects user speaking
+    C->>B: text { type speech.started, data { utterance_id u_user } }
+
+    Note over B: Cancel agent, emit completed for u1
+    B->>C: text { type speech.completed, data { utterance_id u1 } }
+
+    C->>B: binary <pcm 20ms>
+    C->>B: binary <pcm 20ms>
+    C->>B: text { type speech.completed, data { utterance_id u_user } }
+```
+
+
+
+### Error path (customer sends bad message)
+
+```mermaid
+sequenceDiagram
+    participant B as Bluejay
+    participant C as Customer
+
+    C->>B: text { type speech.started, data {} }
+    Note over B: missing utterance_id
+    B->>C: text { type session.error, data { code MISSING_FIELD, message ... } }
+    Note over C: connection stays open; customer can fix and retry
+    C->>B: text { type speech.started, data { utterance_id fixed } }
+    C->>B: binary <pcm>
+```
+
+
+
+---
+
+## Architecture inside our server
+
+```mermaid
+flowchart LR
+    Customer[Customer WS server] -->|"binary PCM 16k"| Recv[Bluejay receive loop]
+    Recv -->|"resample 16k to 48k"| LKAudio[LiveKit AudioSource 48k]
+    LKAudio --> Agent[LiveKit Voice Agent + VAD]
+
+    Agent -->|"agent_speech_started"| EventBridge[Event Bridge]
+    EventBridge -->|"text speech.started"| Send[Bluejay send loop]
+    Send --> Customer
+
+    Agent -->|"TTS PCM 48k"| Mixer[LiveKit Mixer]
+    Mixer -->|"resample 48k to 16k"| Send
+
+    Agent -->|"agent_speech_finished"| EventBridge
+    EventBridge -->|"text speech.completed"| Send
+
+    Customer -->|"text speech.started while agent talking"| Recv
+    Recv -->|"interrupt API call"| Agent
+```
+
+
+
+The translator becomes pure plumbing. No buffers, no VAD, no thresholds, no WAV.
+
+---
+
+## What gets deleted
+
+In [customer_integrations/default_translator.py](customer_integrations/default_translator.py):
+
+- `_parse_audio_data`, `_parse_wav`, `_convert_with_ffmpeg`, `_create_wav` - all format handling
+- `_send_collected_audio_to_customer`, `_process_livekit_audio` - VAD/buffering/amplitude/RMS checks
+- `_buffer_audio_data`, `_continuous_audio_sender` - silence injection
+- All base64 encode/decode of audio
+- `_handle_audio_message` (the JSON-wrapped audio path)
+
+In [customer_integrations/translator.py](customer_integrations/translator.py):
+
+- `AudioMixer` integration (LiveKit agent mixes for us)
+- The 1920-byte chunking / silence-injection plumbing
+
+In [src/models/chirp_message.py](src/models/chirp_message.py):
+
+- `MessageType.STATUS`, `MessageType.CONTROL` - replaced by named events
+- `metadata` and `sender` fields on the envelope
+- Audio convenience constructors (audio is binary now, not a message)
+
+In [tests/websocket_server.py](tests/websocket_server.py):
+
+- WAV combine/silence ratio/meaningful audio analysis (~150 lines)
+
+In `requirements.txt`:
+
+- `ffmpeg-python` (no longer needed)
+
+Net delete: roughly **600 lines**. Net add: roughly **150 lines** (state machine, event bridge, resample, slim envelope, error responder).
+
+---
+
+## Implementation order
+
+1. **Spec freeze.** Confirm this plan.
+2. **Slim message types** in [src/models/chirp_message.py](src/models/chirp_message.py).
+3. **Frame-aware receive loop** in [customer_integrations/translator.py](customer_integrations/translator.py): split text/binary handlers, drop the audio mixer.
+4. **Translator rewrite** in [customer_integrations/default_translator.py](customer_integrations/default_translator.py): just resample + push to LiveKit on inbound, just resample + send binary on outbound.
+5. **Subclass adaptation**: update [customer_integrations/bubba.py](customer_integrations/bubba.py) to the new translator API.
+6. **LiveKit event bridge**: hook agent speech start/finish events to emit `speech.started`/`speech.completed`.
+7. **Customer interrupt path**: when customer sends `speech.started` during an in-flight agent utterance, call LiveKit's agent interrupt API and emit `speech.completed`.
+8. **Error policy**: implement `session.error` responder, classify recoverable vs fatal, map to test_result status.
+9. **Drop dead dependencies**: remove `ffmpeg-python` from `requirements.txt` and any orphaned imports.
+10. **Test server rewrite** in [tests/websocket_server.py](tests/websocket_server.py): match the new wire protocol, keep `--require-auth` and `-l/-r` features. Acts as a stand-in for what a real customer would build.
+11. **Customer-facing spec doc.**
+

--- a/glossary.mdx
+++ b/glossary.mdx
@@ -14,7 +14,7 @@ icon: list-tree
       className="w-full bg-transparent py-2.5 text-sm text-slate-900 placeholder:text-slate-400 dark:text-white dark:placeholder:text-slate-500"
     />
   </div>
-  <p className="mt-2 text-xs text-slate-400 dark:text-slate-500"><span id="glossary-results-count">45</span> terms</p>
+  <p className="mt-2 text-xs text-slate-400 dark:text-slate-500"><span id="glossary-results-count">49</span> terms</p>
 </div>
 
 <div id="glossary-empty-state" className="not-prose mb-10 hidden py-10 text-center">
@@ -40,6 +40,18 @@ See more: [Introduction](/index)
 A notification triggered when a monitored custom metric crosses a configured threshold. Alerts can be delivered via Slack or email and appear as badges on dashboards.
 
 See more: [Alerts Overview](/key-concepts/alerts/overview) | [Slack Integration](/integrations/slack)
+</Accordion></div>
+</section>
+
+<section id="b" data-glossary-section className="not-prose mb-12 scroll-mt-28">
+  <div className="mb-4 flex items-center justify-between gap-4">
+    <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">B</h2>
+    <span className="rounded-full border border-slate-200 px-3 py-1 text-sm text-slate-500 dark:border-white/10 dark:text-slate-400">1 term</span>
+  </div>
+  <div data-glossary-item data-term="Binary Frame"><Accordion title="Binary Frame">
+A WebSocket frame carrying raw bytes rather than UTF-8 text. In the CHIRP protocol, binary frames transport PCM audio samples with no envelope or headers.
+
+See more: [WebSocket Integration](/simulation-integrations/websockets)
 </Accordion></div>
 </section>
 
@@ -191,12 +203,17 @@ See more: [Custom Metrics](/key-concepts/custom-metrics/overview)
 <section id="m" data-glossary-section className="not-prose mb-12 scroll-mt-28">
   <div className="mb-4 flex items-center justify-between gap-4">
     <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">M</h2>
-    <span className="rounded-full border border-slate-200 px-3 py-1 text-sm text-slate-500 dark:border-white/10 dark:text-slate-400">1 term</span>
+    <span className="rounded-full border border-slate-200 px-3 py-1 text-sm text-slate-500 dark:border-white/10 dark:text-slate-400">2 terms</span>
   </div>
   <div data-glossary-item data-term="Metrics Lab"><Accordion title="Metrics Lab">
 An environment where teams draft, human-annotate, test, and refine custom metrics before promoting them to production use. Metrics Lab supports side-by-side comparison of scoring approaches.
 
 See more: [Metrics Lab Overview](/key-concepts/metrics-lab/overview) | [Custom Metrics](/key-concepts/custom-metrics/overview)
+</Accordion></div>
+  <div data-glossary-item data-term="Mono"><Accordion title="Mono">
+Single-channel audio. WebSocket simulations use mono because voice is a single-source signal. All CHIRP audio frames are mono at 16 kHz.
+
+See more: [WebSocket Integration](/simulation-integrations/websockets)
 </Accordion></div>
 </section>
 
@@ -215,8 +232,13 @@ See more: [Observability Overview](/key-concepts/observability/overview) | [Obse
 <section id="p" data-glossary-section className="not-prose mb-12 scroll-mt-28">
   <div className="mb-4 flex items-center justify-between gap-4">
     <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">P</h2>
-    <span className="rounded-full border border-slate-200 px-3 py-1 text-sm text-slate-500 dark:border-white/10 dark:text-slate-400">2 terms</span>
+    <span className="rounded-full border border-slate-200 px-3 py-1 text-sm text-slate-500 dark:border-white/10 dark:text-slate-400">3 terms</span>
   </div>
+  <div data-glossary-item data-term="pcm_s16le"><Accordion title="pcm_s16le">
+Pulse-Code Modulation, signed 16-bit little-endian. A raw audio encoding format where each sample is a 16-bit signed integer stored in little-endian byte order. This is the audio format used by the CHIRP WebSocket protocol.
+
+See more: [WebSocket Integration](/simulation-integrations/websockets)
+</Accordion></div>
   <div data-glossary-item data-term="Prompt Version"><Accordion title="Prompt Version">
 A versioned system prompt with commit messages and labels, enabling prompt experimentation and A/B testing across simulation runs. Prompt versions can be pinned to environments via labels.
 
@@ -259,8 +281,13 @@ See more: [Simulation Types](/test/simulations/types) | [Test Overview](/test/ov
 <section id="s" data-glossary-section className="not-prose mb-12 scroll-mt-28">
   <div className="mb-4 flex items-center justify-between gap-4">
     <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">S</h2>
-    <span className="rounded-full border border-slate-200 px-3 py-1 text-sm text-slate-500 dark:border-white/10 dark:text-slate-400">7 terms</span>
+    <span className="rounded-full border border-slate-200 px-3 py-1 text-sm text-slate-500 dark:border-white/10 dark:text-slate-400">8 terms</span>
   </div>
+  <div data-glossary-item data-term="Sample Rate"><Accordion title="Sample Rate">
+The number of audio samples captured per second, measured in Hz. CHIRP uses 16,000 Hz (16 kHz), the industry standard for speech processing. Higher sample rates capture more frequency detail but increase bandwidth.
+
+See more: [WebSocket Integration](/simulation-integrations/websockets)
+</Accordion></div>
   <div data-glossary-item data-term="Scenario Script"><Accordion title="Scenario Script">
 A natural-language description defining a Digital Human&apos;s goal, constraints, and expected behavior within a simulation. Scenario scripts guide how the synthetic customer interacts with the agent.
 

--- a/simulation-integrations/websockets.mdx
+++ b/simulation-integrations/websockets.mdx
@@ -1,211 +1,123 @@
 ---
-title: 'Websockets Simulations'
-description: 'Realtime messaging over websockets using the CHIRP protocol'
+title: 'Websocket Simulations'
+description: 'Real-time voice over WebSocket using the CHIRP protocol'
 icon: tower-broadcast
 ---
 
-## Websockets
+```mermaid
+sequenceDiagram
+    participant B as Bluejay (WS client)
+    participant C as Your server (WS server)
 
-Bluejay supports realtime, bidirectional communication over websockets. All messages sent to and from Bluejay over a websocket use the CHIRP protocol.
+    B->>C: WS Upgrade + Authorization
+    C-->>B: HTTP 101 Switching Protocols
 
-### What is CHIRP?
+    Note over C: User speaks
+    C->>B: binary frame (PCM 16k mono)
+    C->>B: binary frame (PCM 16k mono)
 
-CHIRP (Conversational Handoff for Inter‑agent Realtime Protocol) is the world’s first real-time A2A communication protocol, enabling conversational agents to interact over websockets over a standard medium of communication. 
+    Note over B: Digital Human responds
+    B->>C: text  speech.started  {utterance_id}
+    B->>C: binary frame (audio)
+    B->>C: binary frame (audio)
+    B->>C: text  speech.completed {utterance_id}
 
-- CHIRP is lightweight, flexible, and message‑oriented, enabling agents and services to exchange text, audio, status, and control information in a consistent envelope without requiring direct integrations between systems. 
-### CHIRP payload schema
-
-```json
-{
-  "id": "uuid-string",
-  "type": "text" | "audio" | "status" | "control",
-  "sender": "source-identifier",
-  "timestamp": "2023-12-07T10:30:00.000Z",
-  "payload": "text content or base64-encoded audio",
-  "metadata": {
-    // optional type-specific fields
-  }
-}
+    C->>B: WS close 1000
 ```
-
-- **required fields**: `type`, `payload`.
-- **optional fields**: `id`, `sender`, `timestamp`, `metadata`.
-- **type** values:
-  - `text`: human- or model-readable UTF‑8 string in `payload`.
-  - `audio`: `payload` is base64-encoded audio bytes; include audio details in `metadata`.
-  - `status`: lifecycle or progress updates.
-  - `control`: session control messages (for example, start/stop, acknowledgements, or protocol signals).
 
 <Note>
-for `audio` messages, `payload` must be a base64-encoded string that decodes to raw audio bytes. Bluejay currently decodes incoming audio as 16,000 Hz (16 kHz) PCM, single channel (mono). custom decoding parameters via the `metadata` object (e.g., sample rate, encoding, channels) will be supported soon.
+`speech.started` and `speech.completed` are optional to ingest, and **not strictly bracketed** around their utterance's binary frames. See [Event ordering](#event-ordering) for details.
 </Note>
 
-Minimal CHIRP example:
+## Overview
 
-```json
-{ "type": "text", "payload": "hello" }
-```
+Bluejay supports real-time, bidirectional voice over WebSocket using **CHIRP**, a transport-only protocol for exchanging raw audio and optional control events between Bluejay and your server.
 
-### Connection model
+[**CHIRP**](/glossary#c) (Conversational Handoff for Inter‑agent Realtime Protocol) is a novel real-time A2A communication protocol, enabling conversational agents to interact over websockets over a standard medium of communication.
 
-Bluejay will initiate a websocket connection to the URL you configure in your Agent’s settings. Once connected, Bluejay will send CHIRP messages and expects your server to respond with CHIRP messages. Every frame in both directions must be a valid CHIRP object.
+The bare minimum integration is accepting a WebSocket connection, validating auth, and exchanging raw PCM binary frames. The three text event types (`speech.started`, `speech.completed`, `session.error`) are all **optional** from your side. Bluejay sends them automatically, but your server can safely ignore every text frame and still have a fully working integration.
 
-### Examples
+### When to use WebSocket
 
-#### Example: `text` message
+Use a WebSocket integration when:
 
-```json
-{
-  "id": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
-  "type": "text",
-  "sender": "client",
-  "timestamp": "2025-01-01T12:00:00.000Z",
-  "payload": "hello, can you help me?"
-}
-```
+- Your agent does not have a phone number.
+- You already have a real-time audio pipeline and want to connect it directly to Bluejay.
+- You need bidirectional streaming with lower latency than telephony.
+- Your system handles raw PCM audio natively.
 
-#### Example: `audio` message
+For other connection types, check out our [other integrations](/simulation-integrations/telephony), or connect via [adding your agent's phone number](/key-concepts/agents/overview).
 
-```json
-{
-  "id": "b5d8a6e8-2cfa-4f9c-9b2a-6f0f3f9a1a23",
-  "type": "audio",
-  "sender": "client",
-  "timestamp": "2025-01-01T12:00:01.000Z",
-  "payload": "<base64-audio-bytes>",
-  "metadata": {
-    "mime": "audio/wav",
-    "sampleRateHz": 16000,
-    "channels": 1
-  }
-}
-```
+---
 
-#### Example: `status` message
+## Quick reference
 
-```json
-{
-  "id": "a2dbf8e4-0767-4a3d-8a29-3f5b7f2c4d10",
-  "type": "status",
-  "sender": "bluejay-agent",
-  "timestamp": "2025-01-01T12:00:02.000Z",
-  "payload": "ready",
-  "metadata": {
-    "code": "session.ready"
-  }
-}
-```
+- **Format**: 16 kHz mono `pcm_s16le` in WebSocket binary frames.
+- **Minimum server**: accept WS, validate Basic auth, read binary, write binary.
+- **Text events** are optional from your side. Bluejay emits `speech.started` / `speech.completed` around Digital Human utterances — **not strictly bracketed**, see [Event ordering](#event-ordering).
+- **Barge-in**: send `speech.started` while the Digital Human is speaking.
+- **Hang up**: close the WebSocket with code `1000`.
 
-#### Example: `control` message
+---
 
-```json
-{
-  "id": "c0e1a39f-92d1-4f1c-9d8a-2a1b3c4d5e6f",
-  "type": "control",
-  "sender": "bluejay-agent",
-  "timestamp": "2025-01-01T12:00:03.000Z",
-  "payload": "invalid or unsupported payload",
-  "metadata": {
-    "code": "bad_request"
-  }
-}
-```
+## Sample server implementations
 
-### Server examples
+Minimal servers that Bluejay can connect to. Each one accepts the WS upgrade, validates Basic auth, and echoes received audio back. Replace the echo with your actual audio source and sink.
 
-Deploy a websocket server and configure its public `ws://` or `wss://` URL in your Agent’s settings. Bluejay will connect to that URL and exchange CHIRP messages.
+<Tabs>
+<Tab title="Basic (audio only)">
+The minimum integration. Handles binary audio frames and ignores everything else.
 
 <CodeGroup>
 
-```js JavaScript (Node.js)
-// npm i ws
-import { WebSocketServer } from 'ws'
-import { randomUUID } from 'crypto'
-
-const port = process.env.PORT ? Number(process.env.PORT) : 8080
-const wss = new WebSocketServer({ port })
-
-wss.on('connection', (ws) => {
-  // send a greeting as CHIRP
-  ws.send(JSON.stringify({
-    id: randomUUID(),
-    type: 'status',
-    sender: 'server',
-    timestamp: new Date().toISOString(),
-    payload: 'ready',
-    metadata: { code: 'session.ready' }
-  }))
-
-  ws.on('message', (data) => {
-    const msg = JSON.parse(data.toString())
-    if (msg.type === 'text') {
-      // echo as text
-      ws.send(JSON.stringify({
-        id: randomUUID(),
-        type: 'text',
-        sender: 'server',
-        timestamp: new Date().toISOString(),
-        payload: `received: ${msg.payload}`
-      }))
-    } else if (msg.type === 'control') {
-      // acknowledge control
-      ws.send(JSON.stringify({
-        id: randomUUID(),
-        type: 'status',
-        sender: 'server',
-        timestamp: new Date().toISOString(),
-        payload: 'ack',
-        metadata: { code: 'control.ack' }
-      }))
-    }
-  })
-})
-
-console.log(`ws server listening on :${port}`)
-```
-
-```python Python (asyncio)
+```python Python (websockets)
 # pip install websockets
-import asyncio
-import json
-import os
-import uuid
-import websockets
-from datetime import datetime, timezone
+import asyncio, base64, os
+from websockets.asyncio.server import serve
 
-PORT = int(os.environ.get('PORT', '8080'))
+USER, PASS = os.environ["CHIRP_USER"], os.environ["CHIRP_PASS"]
+EXPECTED = "Basic " + base64.b64encode(f"{USER}:{PASS}".encode()).decode()
 
 async def handler(ws):
-    # send greeting
-    await ws.send(json.dumps({
-        "id": str(uuid.uuid4()),
-        "type": "status",
-        "sender": "server",
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "payload": "ready",
-        "metadata": {"code": "session.ready"}
-    }))
+    if ws.request.headers.get("Authorization") != EXPECTED:
+        await ws.close(1008, "unauthorized"); return
 
-    async for raw in ws:
-        msg = json.loads(raw)
-        if msg.get("type") == "text":
-            await ws.send(json.dumps({
-                "type": "text",
-                "payload": f"received: {msg.get('payload')}"
-            }))
-        elif msg.get("type") == "control":
-            await ws.send(json.dumps({
-                "type": "status",
-                "payload": "ack",
-                "metadata": {"code": "control.ack"}
-            }))
+    async for msg in ws:
+        if isinstance(msg, bytes):
+            await ws.send(msg)
 
 async def main():
-    async with websockets.serve(handler, host="0.0.0.0", port=PORT):
-        print(f"ws server listening on :{PORT}")
+    async with serve(handler, "0.0.0.0", 8080):
         await asyncio.Future()
 
 asyncio.run(main())
+```
+
+```typescript TypeScript (ws)
+// npm i ws
+import { createServer } from 'http'
+import { WebSocketServer } from 'ws'
+
+const { CHIRP_USER, CHIRP_PASS } = process.env
+const expected = 'Basic ' + Buffer.from(`${CHIRP_USER}:${CHIRP_PASS}`).toString('base64')
+
+const server = createServer()
+const wss = new WebSocketServer({ noServer: true })
+
+server.on('upgrade', (req, socket, head) => {
+  if (req.headers.authorization !== expected) {
+    socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n'); socket.destroy(); return
+  }
+  wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws, req))
+})
+
+wss.on('connection', (ws) => {
+  ws.on('message', (data, isBinary) => {
+    if (isBinary) ws.send(data, { binary: true })
+  })
+})
+
+server.listen(8080)
 ```
 
 ```go Go (gorilla/websocket)
@@ -213,62 +125,444 @@ asyncio.run(main())
 package main
 
 import (
-    "encoding/json"
-    "log"
+    "crypto/subtle"
+    "encoding/base64"
     "net/http"
-    "time"
+    "os"
 
     "github.com/gorilla/websocket"
 )
 
-type Chirp map[string]any
-
-var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
-
-func handler(w http.ResponseWriter, r *http.Request) {
-    c, err := upgrader.Upgrade(w, r, nil)
-    if err != nil { log.Println("upgrade:", err); return }
-    defer c.Close()
-
-    // greeting
-    ready := Chirp{
-        "type":      "status",
-        "payload":   "ready",
-        "metadata":  map[string]any{"code": "session.ready"},
-        "timestamp": time.Now().UTC().Format(time.RFC3339Nano),
-    }
-    if b, _ := json.Marshal(ready); c.WriteMessage(websocket.TextMessage, b) != nil { return }
-
-    for {
-        _, message, err := c.ReadMessage()
-        if err != nil { log.Println("read:", err); return }
-        var msg Chirp
-        if err := json.Unmarshal(message, &msg); err != nil { log.Println(err); continue }
-
-        switch msg["type"] {
-        case "text":
-            resp := Chirp{"type": "text", "payload": "received: " + msg["payload"].(string)}
-            b, _ := json.Marshal(resp)
-            _ = c.WriteMessage(websocket.TextMessage, b)
-        case "control":
-            resp := Chirp{"type": "status", "payload": "ack", "metadata": map[string]any{"code": "control.ack"}}
-            b, _ := json.Marshal(resp)
-            _ = c.WriteMessage(websocket.TextMessage, b)
-        }
-    }
-}
+var up = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
 
 func main() {
-    http.HandleFunc("/ws", handler)
-    log.Println("ws server listening on :8080/ws")
-    log.Fatal(http.ListenAndServe(":8080", nil))
+    expected := "Basic " + base64.StdEncoding.EncodeToString(
+        []byte(os.Getenv("CHIRP_USER")+":"+os.Getenv("CHIRP_PASS")))
+
+    http.HandleFunc("/voice", func(w http.ResponseWriter, r *http.Request) {
+        if subtle.ConstantTimeCompare([]byte(r.Header.Get("Authorization")), []byte(expected)) != 1 {
+            http.Error(w, "unauthorized", 401); return
+        }
+        c, err := up.Upgrade(w, r, nil)
+        if err != nil { return }
+        defer c.Close()
+        for {
+            mt, msg, err := c.ReadMessage()
+            if err != nil { return }
+            if mt == websocket.BinaryMessage {
+                _ = c.WriteMessage(websocket.BinaryMessage, msg)
+            }
+        }
+    })
+    http.ListenAndServe(":8080", nil)
 }
 ```
 
+```js Node.js (ws)
+// npm i ws
+const { createServer } = require('http')
+const { WebSocketServer } = require('ws')
+
+const expected = 'Basic ' + Buffer
+  .from(`${process.env.CHIRP_USER}:${process.env.CHIRP_PASS}`).toString('base64')
+
+const server = createServer()
+const wss = new WebSocketServer({ noServer: true })
+
+server.on('upgrade', (req, socket, head) => {
+  if (req.headers.authorization !== expected) {
+    socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n'); return socket.destroy()
+  }
+  wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws))
+})
+
+wss.on('connection', (ws) => {
+  ws.on('message', (data, isBinary) => {
+    if (isBinary) ws.send(data, { binary: true })
+  })
+})
+
+server.listen(8080)
+```
+
+```ruby Ruby (async-websocket)
+# gem install async-websocket async-http falcon
+require 'async'
+require 'async/http/endpoint'
+require 'async/websocket/adapters/rack'
+require 'base64'
+
+EXPECTED = "Basic " + Base64.strict_encode64("#{ENV['CHIRP_USER']}:#{ENV['CHIRP_PASS']}")
+
+app = lambda do |env|
+  return [401, {}, ['unauthorized']] unless env['HTTP_AUTHORIZATION'] == EXPECTED
+  Async::WebSocket::Adapters::Rack.open(env) do |ws|
+    while msg = ws.read
+      ws.write(msg) if msg.buffer.is_a?(String) && msg.buffer.encoding == Encoding::ASCII_8BIT
+    end
+  end
+end
+
+Async { Async::HTTP::Server.for(Async::HTTP::Endpoint.parse('http://0.0.0.0:8080'), app).run }
+```
+
 </CodeGroup>
+</Tab>
+<Tab title="With text events">
+Handles text events alongside audio. Use this when you want to react to `speech.started` / `speech.completed` (e.g. to mute playback on barge-in, drive a UI indicator, or send your own events back).
 
-### Tips
+<Note>
+These handlers log speech events but keep forwarding **every** binary frame regardless, because audio may arrive both before `speech.started` and after `speech.completed` for the same `utterance_id`. See [Event ordering](#event-ordering).
+</Note>
 
-- only `type` and `payload` are required; add other fields as needed for correlation and context.
-- include rich `metadata` to convey audio format or application context; consumers should ignore fields they do not understand.
-- treat every websocket frame as a complete CHIRP message; avoid streaming partial JSON. 
+<CodeGroup>
+
+```python Python (websockets)
+# pip install websockets
+import asyncio, base64, json, os, uuid, time
+from websockets.asyncio.server import serve
+
+USER, PASS = os.environ["CHIRP_USER"], os.environ["CHIRP_PASS"]
+EXPECTED = "Basic " + base64.b64encode(f"{USER}:{PASS}".encode()).decode()
+
+def make_event(event_type, data):
+    return json.dumps({
+        "type": event_type,
+        "id": str(uuid.uuid4()),
+        "ts_ms": int(time.time() * 1000),
+        "data": data,
+    })
+
+async def handler(ws):
+    if ws.request.headers.get("Authorization") != EXPECTED:
+        await ws.close(1008, "unauthorized"); return
+
+    current_utterance = None
+
+    async for msg in ws:
+        if isinstance(msg, bytes):
+            await ws.send(msg)
+        else:
+            event = json.loads(msg)
+            if event["type"] == "speech.started":
+                current_utterance = event["data"]["utterance_id"]
+                print(f"Digital Human started speaking: {current_utterance}")
+            elif event["type"] == "speech.completed":
+                print(f"Digital Human finished: {event['data']['utterance_id']}")
+                current_utterance = None
+            elif event["type"] == "session.error":
+                print(f"Error: {event['data']['code']}: {event['data']['message']}")
+
+async def main():
+    async with serve(handler, "0.0.0.0", 8080):
+        await asyncio.Future()
+
+asyncio.run(main())
+```
+
+```typescript TypeScript (ws)
+// npm i ws
+import { createServer } from 'http'
+import { WebSocketServer, type WebSocket } from 'ws'
+import { randomUUID } from 'crypto'
+
+const { CHIRP_USER, CHIRP_PASS } = process.env
+const expected = 'Basic ' + Buffer.from(`${CHIRP_USER}:${CHIRP_PASS}`).toString('base64')
+
+function makeEvent(type: string, data: Record<string, unknown>) {
+  return JSON.stringify({ type, id: randomUUID(), ts_ms: Date.now(), data })
+}
+
+const server = createServer()
+const wss = new WebSocketServer({ noServer: true })
+
+server.on('upgrade', (req, socket, head) => {
+  if (req.headers.authorization !== expected) {
+    socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n'); socket.destroy(); return
+  }
+  wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws, req))
+})
+
+wss.on('connection', (ws: WebSocket) => {
+  let currentUtterance: string | null = null
+
+  ws.on('message', (data, isBinary) => {
+    if (isBinary) {
+      ws.send(data, { binary: true })
+      return
+    }
+
+    const event = JSON.parse(data.toString())
+    switch (event.type) {
+      case 'speech.started':
+        currentUtterance = event.data.utterance_id
+        console.log(`Digital Human started speaking: ${currentUtterance}`)
+        break
+      case 'speech.completed':
+        console.log(`Digital Human finished: ${event.data.utterance_id}`)
+        currentUtterance = null
+        break
+      case 'session.error':
+        console.error(`Error: ${event.data.code}: ${event.data.message}`)
+        break
+    }
+  })
+})
+
+server.listen(8080)
+```
+
+</CodeGroup>
+</Tab>
+</Tabs>
+
+---
+
+## Message formats
+
+CHIRP uses two WebSocket frame types: **binary** for audio (required) and **text** for control events (optional). **A minimum integration only needs binary.**
+
+<Tabs>
+<Tab title="Binary (audio)">
+Each binary frame is raw audio samples. Both sides send and receive them.
+
+| Property    | Value                                              | Notes                              |
+| ----------- | -------------------------------------------------- | ---------------------------------- |
+| Encoding    | [`pcm_s16le`](/glossary#p)                         | Signed 16-bit little-endian PCM    |
+| [Sample rate](/glossary#s) | **16 000 Hz**                       | Industry standard for speech AI    |
+| Channels    | **1 ([mono](/glossary#m))**                        | Voice is single-channel            |
+| Frame size  | Recommended 20 ms (640 bytes). Any even length OK. | Must be even (samples are 2 bytes) |
+</Tab>
+<Tab title="speech.started (optional)">
+Signals the start of a turn. Sent as a WebSocket text frame (UTF-8 JSON).
+
+```json
+{
+  "type":  "speech.started",
+  "id":    "c0e1a39f-92d1-4f1c-9d8a-2a1b3c4d5e6f",
+  "ts_ms": 1729123456789,
+  "data":  { "utterance_id": "u_abc123" }
+}
+```
+
+| Field         | Type    | Required | Notes                                       |
+| ------------- | ------- | -------- | ------------------------------------------- |
+| `type`        | string  | Yes      | `"speech.started"`                          |
+| `id`          | string  | Yes      | UUID (auto-filled by Bluejay if omitted)    |
+| `ts_ms`       | integer | Yes      | Unix epoch ms (auto-filled if omitted)      |
+| `utterance_id`| string  | Yes      | Unique within the session (UUID or counter) |
+
+**Bluejay sends this** when Bluejay's VAD detects the Digital Human has begun speaking. The event is **not a precise boundary**: the first few binary audio frames of the utterance may arrive before `speech.started`, and the last few may arrive after `speech.completed`. See [Event ordering](#event-ordering).
+
+**You can send this** to signal a new user turn. If the Digital Human is mid-utterance, Bluejay interrupts it and emits `speech.completed` for the canceled utterance.
+</Tab>
+<Tab title="speech.completed (optional)">
+Signals the end of a turn. Sent as a WebSocket text frame (UTF-8 JSON).
+
+```json
+{
+  "type":  "speech.completed",
+  "id":    "a2dbf8e4-0767-4a3d-8a29-3f5b7f2c4d10",
+  "ts_ms": 1729123460220,
+  "data":  { "utterance_id": "u_abc123" }
+}
+```
+
+| Field         | Type    | Required | Notes                                    |
+| ------------- | ------- | -------- | ---------------------------------------- |
+| `type`        | string  | Yes      | `"speech.completed"`                     |
+| `id`          | string  | Yes      | UUID (auto-filled by Bluejay if omitted) |
+| `ts_ms`       | integer | Yes      | Unix epoch ms (auto-filled if omitted)   |
+| `utterance_id`| string  | Yes      | Must match a prior `speech.started` id   |
+
+**Bluejay sends this** when Bluejay's VAD declares end-of-speech for the utterance. Some trailing binary audio frames for the same `utterance_id` may still arrive after this event. Do not use `speech.completed` as a hard cutoff for audio playback — see [Event ordering](#event-ordering).
+
+**You can send this** to tell Bluejay the user is done talking, letting Bluejay respond faster.
+</Tab>
+<Tab title="session.error (optional)">
+Reports a protocol violation or server-side issue. This is part of the CHIRP protocol, sent as a WebSocket text frame (UTF-8 JSON) over the same connection.
+
+```json
+{
+  "type":  "session.error",
+  "id":    "b1-err-0001",
+  "ts_ms": 1729123462000,
+  "data": {
+    "code":    "INVALID_MESSAGE",
+    "message": "Unexpected type 'foo'"
+  }
+}
+```
+
+| Field     | Type    | Required | Notes                                    |
+| --------- | ------- | -------- | ---------------------------------------- |
+| `type`    | string  | Yes      | `"session.error"`                        |
+| `id`      | string  | Yes      | UUID (auto-filled by Bluejay if omitted) |
+| `ts_ms`   | integer | Yes      | Unix epoch ms (auto-filled if omitted)   |
+| `code`    | string  | Yes      | One of the error codes below             |
+| `message` | string  | Yes      | Human-readable detail for debugging      |
+
+**Error codes:**
+
+| Code                  | Meaning                                                  |
+| --------------------- | -------------------------------------------------------- |
+| `INVALID_MESSAGE`     | Malformed JSON or unknown `type`                         |
+| `MISSING_FIELD`       | Required field absent                                    |
+| `INVALID_AUDIO_FRAME` | Binary frame is empty or has odd byte length             |
+| `INTERNAL_ERROR`      | Bug on sender's side; connection closes after this frame |
+
+Recoverable errors (all except `INTERNAL_ERROR`) do not close the connection. The offending frame is dropped and the session continues.
+</Tab>
+</Tabs>
+
+---
+
+## Error handling
+
+| Scenario                                | Bluejay behavior                                       |
+| --------------------------------------- | ------------------------------------------------------ |
+| HTTP 401/403 on upgrade                 | `test_result.status = REJECTED`                        |
+| Host unreachable / TCP refused / TLS failure | 3 retries with backoff, then `INCOMPLETED`        |
+| Upgrade accepted but closed immediately | `INCOMPLETED`, close code logged                       |
+| Protocol violation (bad JSON, missing field, odd-length audio) | `session.error` sent, frame dropped, session continues |
+| Your server closes gracefully           | Session torn down; status set by call completion       |
+| Network drop or crash                   | `INCOMPLETED`, session ended                           |
+
+If you send a `session.error`, Bluejay logs it and surfaces it in `test_result.metadata`. The connection stays open unless you also close it.
+
+| Close code | Meaning                                    |
+| ---------- | ------------------------------------------ |
+| `1000`     | Normal closure                             |
+| `1008`     | Policy violation (typically auth rejected) |
+| `1011`     | Internal error on sender's side            |
+
+---
+
+## How it works
+
+### Connection lifecycle
+
+<Steps>
+<Step title="Bluejay opens the WebSocket">
+Bluejay dials the URL you configured on your Agent (e.g. `wss://your-host/voice`) and sends an HTTP upgrade with an `Authorization: Basic <base64(user:pass)>` header.
+</Step>
+
+<Step title="Your server accepts or rejects">
+- Valid credentials: respond with `HTTP 101 Switching Protocols` and the WS is live.
+- Invalid credentials: respond with `HTTP 401`. Bluejay marks the run as `REJECTED`.
+</Step>
+
+<Step title="Exchange audio">
+- When you want to send audio, send it as a WebSocket [binary frame](/glossary#b) of raw [`pcm_s16le`](/glossary#p) at **16 kHz** [mono](/glossary#m).
+- When you receive a binary frame from Bluejay, play it back as raw `pcm_s16le` at **16 kHz** mono. That is the Digital Human's voice.
+</Step>
+
+<Step title="(Optional) React to text events">
+Bluejay emits `speech.started` / `speech.completed` text frames around every utterance. You can ignore them or use them to drive UI. They are **not strictly bracketed** around their audio — see [Event ordering](#event-ordering).
+</Step>
+
+<Step title="Hang up">
+Close with code `1000` for a normal end. Bluejay will also close `1000` when the test run completes.
+</Step>
+</Steps>
+
+### Event ordering
+
+`speech.started` and `speech.completed` are **derived from voice-activity detection**, which runs on an independent clock from the audio reader. They are **not a precise timestamp** for when an utterance's binary audio starts or ends on the wire.
+
+In practice, you should expect this skew:
+
+| Event              | Can be offset by                    | From                                   |
+| ------------------ | ----------------------------------- | -------------------------------------- |
+| `speech.started`   | up to **~200 ms late**              | The first binary frame of the turn     |
+| `speech.completed` | up to **~200 ms early**             | The last binary frame of the turn      |
+
+Why: VAD needs an analysis window before it can declare that speech has started, and it declares end-of-speech before the underlying audio stream buffer fully drains.
+
+```mermaid
+sequenceDiagram
+    participant B as Bluejay
+    participant C as Your server
+
+    B->>C: binary (audio, start of turn)
+    B->>C: binary (audio)
+    Note over B: VAD declares speech started (~200 ms in)
+    B->>C: text speech.started {utterance_id: u1}
+    B->>C: binary (audio)
+    B->>C: binary (audio)
+    Note over B: VAD declares end-of-speech before buffer drains
+    B->>C: text speech.completed {utterance_id: u1}
+    B->>C: binary (audio, trailing)
+    B->>C: binary (audio, trailing)
+```
+
+**What this means for your server:**
+
+- **Do not assume** binary frames arrive only between `speech.started` and `speech.completed` for a given `utterance_id`. A few frames on either side are normal.
+- **Do not use** `speech.completed` as a hard signal to stop playing audio. Continue playing binary frames as they arrive; end-of-utterance on the wire is when frames stop (or a new `speech.started` with a different `utterance_id` arrives).
+- **Do use** `utterance_id` to group audio with its speech events for logging, UI, or analytics, but treat the association as best-effort around the boundaries.
+- **Minimum-integration servers** (binary only) are unaffected — they never see these events.
+
+---
+
+## Sample session
+
+```text
+# 1. Handshake
+[Bluejay  -> Server]  GET /voice HTTP/1.1
+                      Authorization: Basic dG9tYXM6dG9tYXM=
+                      Upgrade: websocket
+[Server   -> Bluejay] HTTP/1.1 101 Switching Protocols
+
+# 2. User speaks
+[Server   -> Bluejay] binary <640 B: 20 ms of audio @ 16k mono>
+[Server   -> Bluejay] binary <640 B>
+[Server   -> Bluejay] binary <640 B>
+
+# 3. Digital Human responds.
+#    Note: speech.started arrives AFTER the first few audio frames (VAD analysis window),
+#    and speech.completed arrives BEFORE the last few audio frames (VAD end-of-speech
+#    declared before the audio buffer drains). See "Event ordering".
+[Bluejay  -> Server]  binary <640 B: Digital Human audio>
+[Bluejay  -> Server]  binary <640 B>
+[Bluejay  -> Server]  text   {"type":"speech.started","data":{"utterance_id":"agent-u1"}, ...}
+[Bluejay  -> Server]  binary <640 B>
+[Bluejay  -> Server]  binary <640 B>
+[Bluejay  -> Server]  text   {"type":"speech.completed","data":{"utterance_id":"agent-u1"}, ...}
+[Bluejay  -> Server]  binary <640 B: trailing audio for agent-u1>
+[Bluejay  -> Server]  binary <640 B: trailing audio for agent-u1>
+
+# 4. Hang up
+[Server   -> Bluejay] WS close 1000 "call ended"
+```
+
+---
+
+## Barge-in
+
+If you run your own VAD or push-to-talk, send `speech.started` while the Digital Human is mid-utterance to **interrupt** it. There is no separate interrupt message; `speech.started` _is_ the interrupt.
+
+```mermaid
+sequenceDiagram
+    participant B as Bluejay
+    participant C as Your server
+
+    B->>C: text  speech.started   {utterance_id: agent-u1}
+    B->>C: binary (audio)
+    B->>C: binary (audio)
+
+    Note over C: Your VAD detects user talking over the Digital Human
+    C->>B: text  speech.started   {utterance_id: user-u1}
+
+    Note over B: Interrupts Bluejay Digital Human
+    B->>C: text  speech.completed {utterance_id: agent-u1}
+
+    C->>B: binary (user audio)
+    C->>B: binary (user audio)
+    C->>B: text  speech.completed {utterance_id: user-u1}
+```
+
+| You send `speech.started` while...    | Bluejay's behavior                                                                                            |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Digital Human is mid-utterance        | Stops sending audio, interrupts the Digital Human, emits `speech.completed` for the canceled utterance, listens |
+| Digital Human is idle                 | Informational. Bluejay picks up user audio from binary frames regardless.                                      |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rewrite CHIRP as a transport‑only WebSocket protocol: audio is raw 16 kHz mono `pcm_s16le` in binary frames; text events are optional. Reworked WebSocket docs with minimal server examples, event ordering, barge‑in, and error policy; added glossary terms.

- **New Features**
  - Added `chirp_rewrite.md`: CHIRP v2 spec (roles, wire format, `speech.started`/`speech.completed`/`session.error`, error codes).
  - Rewrote WebSocket guide for binary PCM both ways, with barge‑in behavior and connection lifecycle.
  - Included minimal servers (Python, Node/TS, Go, Ruby) that validate Basic auth and stream audio.
  - Documented event ordering: speech events are not strictly bracketed around audio.
  - Expanded glossary with Binary Frame, Mono, `pcm_s16le`, and Sample Rate.

- **Migration**
  - Stream 16 kHz mono `pcm_s16le` as WS binary frames; drop base64/WAV and any audio JSON envelopes.
  - Treat text frames as optional; use `speech.started` to interrupt if the agent is speaking.
  - Validate `Authorization: Basic` on upgrade; close with code `1000` to end sessions.
  - Do not stop playback at `speech.completed`; keep playing trailing binary frames.

<sup>Written for commit cc1f1d8ada26a263d8083e47fac8f2828eb78878. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

