### PR TITLE
changelog: add April 23rd, 2026 updates

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,46 @@ icon: clock
 rss: true
 ---
 
+<Update label="April 23rd, 2026" tags={["New", "Digital Humans"]}>
+  ## DTMF tool for Digital Humans
+
+  Digital humans can now be configured to send DTMF tones during a call via a new **`allow_dtmf_tool`** field, aligned with how **`allow_end_call_tool`** and **`allow_silence_tool`** are stored and returned. Create and bulk-create default to `allow_dtmf_tool: true` when omitted; updates treat the field as optional (omit to leave unchanged). OpenAPI schemas **`DigitalHumanRequestData`**, **`DigitalHumanResponseData`**, and **`UpdateDigitalHumanRequest`** include the new property.
+
+  [Create digital human](/api-reference/endpoint/create-digital-human) · [Update digital human](/api-reference/endpoint/update-digital-human)
+</Update>
+
+<Update label="April 23rd, 2026" tags={["New", "Simulations"]}>
+  ## Runs per Digital Human
+
+  Simulations now support executing multiple runs for each selected digital human in a single batch. Set **`runs_per_digital_human`** on the simulation (persisted in `experiments.settings`) to control the default, or pass an explicit per-run override when queuing a run. Values must be positive integers; when unset, each digital human runs once. The Bluejay dashboard exposes the new control on the simulation settings page and the "Create simulation" and "Create new run" dialogs.
+
+  [Simulations overview](/key-concepts/simulations/overview)
+</Update>
+
+<Update label="April 23rd, 2026" tags={["Improvement", "Digital Humans"]}>
+  ## Digital Human intelligence upgrade
+
+  We upgraded the reasoning quality of digital humans during both simulations and observability replays. Expect more coherent multi-turn behavior, better adherence to persona and objectives, and steadier tool-use decisions across longer conversations. No configuration changes are required — the upgrade applies automatically to all digital humans.
+
+  [Digital humans overview](/key-concepts/digital-humans/overview)
+</Update>
+
+<Update label="April 23rd, 2026" tags={["Improvement", "Workflows"]}>
+  ## Scripted silence in workflows
+
+  When a digital human is running in workflow mode, the silence tool now evaluates only at end-of-turn instead of firing from timeout-based checks mid-turn. This removes a class of false silence triggers on scripted workflow steps and keeps silence decisions aligned with the workflow's turn boundaries. Non-workflow digital humans are unchanged.
+
+  [Workflows overview](/key-concepts/workflows/overview)
+</Update>
+
+<Update label="April 23rd, 2026" tags={["Performance", "Workflows"]}>
+  ## Workflow latency fix
+
+  Fixed a latency regression in workflow-mode conversations where session-handler state could delay turn transitions. Workflow runs now advance between agent and user turns without the extra wait, improving perceived responsiveness on branching paths.
+
+  [Workflows overview](/key-concepts/workflows/overview)
+</Update>
+
 <Update label="April 14th, 2026" tags={["Improvement", "API"]}>
   ## Digital Human: silence tool fields
 


### PR DESCRIPTION
## Summary
Adds five entries to the changelog for the week of April 17–23, 2026, all dated **April 23rd, 2026**:

- **DTMF tool for Digital Humans** — new `allow_dtmf_tool` field on DH create/read/update/bulk endpoints (default `true`), aligned with the existing `allow_end_call_tool` / `allow_silence_tool` pattern.
- **Runs per Digital Human** — new `runs_per_digital_human` setting on simulations (persisted in `experiments.settings`) plus a dashboard control on the simulation settings page and the create-simulation / create-new-run dialogs.
- **Digital Human intelligence upgrade** — generalized quality improvement to DH reasoning across simulations and observability replays; no configuration required.
- **Scripted silence in workflows** — silence tool now evaluates only at end-of-turn when in workflow mode, eliminating false mid-turn triggers on scripted steps.
- **Workflow latency fix** — fix for a session-handler-induced delay between workflow turn transitions.

## Test plan
- [ ] Preview the changelog page locally and confirm the five new `<Update>` blocks render with correct tags, ordering, and links.
- [ ] Verify links resolve: `/api-reference/endpoint/create-digital-human`, `/api-reference/endpoint/update-digital-human`, `/key-concepts/simulations/overview`, `/key-concepts/digital-humans/overview`, `/key-concepts/workflows/overview`.
- [ ] Confirm RSS feed picks up the new entries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five April 23, 2026 changelog entries to document a new DTMF tool option, a runs-per-digital-human setting, an intelligence upgrade, workflow silence handling changes, and a workflow latency fix.

- **New Features**
  - Digital Humans: add `allow_dtmf_tool` (default `true` on create/bulk; optional on update), aligned with `allow_end_call_tool`/`allow_silence_tool`; OpenAPI types updated.
  - Simulations: add `runs_per_digital_human` (positive integer, stored in `experiments.settings`) with dashboard controls.

- **Improvements**
  - Better DH reasoning across simulations and observability replays; no config needed.
  - In workflows, the silence tool evaluates only at end-of-turn to avoid mid-turn false triggers.
  - Fix workflow latency from session-handler delays between turns.

<sup>Written for commit 2fb4d5e04cf20d664ef013e79c39ca2c847151d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

