### PR TITLE
Dev

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,46 @@ icon: clock
 rss: true
 ---
 
+<Update label="April 23rd, 2026" tags={["New", "Digital Humans"]}>
+  ## DTMF tool for Digital Humans
+
+  Digital humans can now be configured to send DTMF tones during a call via a new **`allow_dtmf_tool`** field, aligned with how **`allow_end_call_tool`** and **`allow_silence_tool`** are stored and returned. Create and bulk-create default to `allow_dtmf_tool: true` when omitted; updates treat the field as optional (omit to leave unchanged). OpenAPI schemas **`DigitalHumanRequestData`**, **`DigitalHumanResponseData`**, and **`UpdateDigitalHumanRequest`** include the new property.
+
+  [Create digital human](/api-reference/endpoint/create-digital-human) · [Update digital human](/api-reference/endpoint/update-digital-human)
+</Update>
+
+<Update label="April 23rd, 2026" tags={["New", "Simulations"]}>
+  ## Runs per Digital Human
+
+  Simulations now support executing multiple runs for each selected digital human in a single batch. Set **`runs_per_digital_human`** on the simulation (persisted in `experiments.settings`) to control the default, or pass an explicit per-run override when queuing a run. Values must be positive integers; when unset, each digital human runs once. The Bluejay dashboard exposes the new control on the simulation settings page and the "Create simulation" and "Create new run" dialogs.
+
+  [Simulations overview](/key-concepts/simulations/overview)
+</Update>
+
+<Update label="April 23rd, 2026" tags={["Improvement", "Digital Humans"]}>
+  ## Digital Human intelligence upgrade
+
+  We upgraded the reasoning quality of digital humans during both simulations and observability replays. Expect more coherent multi-turn behavior, better adherence to persona and objectives, and steadier tool-use decisions across longer conversations. No configuration changes are required — the upgrade applies automatically to all digital humans.
+
+  [Digital humans overview](/key-concepts/digital-humans/overview)
+</Update>
+
+<Update label="April 23rd, 2026" tags={["Improvement", "Workflows"]}>
+  ## Scripted silence in workflows
+
+  When a digital human is running in workflow mode, the silence tool now evaluates only at end-of-turn instead of firing from timeout-based checks mid-turn. This removes a class of false silence triggers on scripted workflow steps and keeps silence decisions aligned with the workflow's turn boundaries. Non-workflow digital humans are unchanged.
+
+  [Workflows overview](/key-concepts/workflows/overview)
+</Update>
+
+<Update label="April 23rd, 2026" tags={["Performance", "Workflows"]}>
+  ## Workflow latency fix
+
+  Fixed a latency regression in workflow-mode conversations where session-handler state could delay turn transitions. Workflow runs now advance between agent and user turns without the extra wait, improving perceived responsiveness on branching paths.
+
+  [Workflows overview](/key-concepts/workflows/overview)
+</Update>
+
 <Update label="April 14th, 2026" tags={["Improvement", "API"]}>
   ## Digital Human: silence tool fields
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds April 23, 2026 changelog updates. Includes `allow_dtmf_tool` for digital humans, per-digital-human run counts in simulations, a reasoning upgrade, end-of-turn silence evaluation in workflow mode, and a workflow latency fix.

<sup>Written for commit c1bf3f3e04f1e75669ef9f92c2de02e658c503a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

