### PR TITLE
tool call integration

### DIFF
--- a/simulation-integrations/livekit.mdx
+++ b/simulation-integrations/livekit.mdx
@@ -23,3 +23,41 @@ Bluejay will create a room inside of your livekit cloud instance and dispatch yo
 ## Room Metadata
 
 Optionally, you can add any metadata you want to be included in the room on room creation. Simply add the JSON metadata to the metadata section in the Agent Connection settings.
+
+## Tool Call Tracking
+
+Bluejay can capture tool calls your agent makes during a simulation. Just publish a data packet to a LiveKit topic and Bluejay can ingest it.
+
+### Setup
+
+In your Agent Connection settings, set the **LiveKit Customer Tool Topic** field to the topic name your code will publish to (e.g. `customer.tool.calls`).
+
+### Publishing a Tool Call
+
+Whenever your agent invokes a tool, publish a JSON payload to your configured topic:
+
+```python
+import json
+from livekit import rtc
+
+async def report_tool_call(room: rtc.Room, tool_name: str, parameters: dict, output):
+    payload = json.dumps({
+        "name": tool_name,
+        "parameters": parameters,
+        "output": output,
+    }).encode()
+    await room.local_participant.publish_data(payload, topic="customer.tool.calls")
+```
+
+The only required field is `name`. Everything else is optional:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | **Required.** The tool that was invoked |
+| `parameters` | object | Input parameters passed to the tool |
+| `output` | any | Return value of the tool |
+| `invocation_id` | string | Unique ID to prevent duplicate ingestion on retries |
+| `start_offset_ms` | integer | Milliseconds from call start (Bluejay calculates if omitted) |
+| `client_ts` | string | ISO 8601 timestamp, used to calculate offset if `start_offset_ms` is not set |
+
+Bluejay buffers packets during the call and persists them automatically when the simulation ends.

--- a/test/simulations/tool-calls.mdx
+++ b/test/simulations/tool-calls.mdx
@@ -20,7 +20,7 @@ flowchart LR
 
 ## Integration Methods
 
-Bluejay supports two methods for passing the `X-Simulation-Result-Id` to your agent, depending on your infrastructure.
+Bluejay supports three methods for tool call tracking, depending on your infrastructure.
 
 ### SIP Integration (Recommended for Phone Systems)
 
@@ -49,6 +49,19 @@ WebSocket integration using the CHIRP protocol provides real-time, bidirectional
 4. After the call ends, you must send the collected data to [`/v1/update-simulation-result`](/api-reference/endpoint/update-simulation-result)
 
 [WebSocket Integration Guide →](/simulation-integrations/websockets)
+
+### LiveKit Integration
+
+**Best for**: agents built on the LiveKit Agents framework.
+
+Bluejay joins the LiveKit room alongside your agent. When your agent invokes a tool, publish a data packet to a configured topic and Bluejay ingests it automatically — no post-call API call needed.
+
+**Flow:**
+1. Set the **LiveKit Customer Tool Topic** in your Agent Connection settings
+2. Publish a JSON packet to that topic whenever your agent calls a tool
+3. Bluejay ingests packets in real time and persists them when the call ends
+
+[LiveKit Integration Guide →](/simulation-integrations/livekit#tool-call-tracking)
 
 ### Why SIP for Phone-Based Agents?
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds LiveKit tool call tracking so agents can publish tool events to a LiveKit topic for real-time ingestion. Updates the tool-calls guide to include LiveKit as a third integration path.

- **New Features**
  - Documented LiveKit tool call tracking with setup via the “LiveKit Customer Tool Topic”.
  - Added a Python example for publishing JSON payloads (`name` required; `parameters`, `output`, `invocation_id`, `start_offset_ms`, `client_ts` optional).
  - Clarified that Bluejay buffers packets during the call and persists them at simulation end.
  - Updated the tool-calls guide to add the LiveKit flow and link to the new section.

<sup>Written for commit 5acfb34269ce673bf9e81194b0cc8c4d07f4c172. Summary will update on new commits. <a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/181?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

