### PR TITLE
Clarify endpointing_delay is referenced as patience in the UI

### DIFF
--- a/api-reference/endpoint/create-digital-human.mdx
+++ b/api-reference/endpoint/create-digital-human.mdx
@@ -112,6 +112,8 @@ Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpo
 }
 ```
 
+> **Note:** `endpointing_delay` is referenced as **patience** in the UI. It controls how long (in seconds) the digital human waits after silence before assuming the speaker has finished talking.
+
 Refer to the full schema at https://docs.getbluejay.ai/api-reference/endpoint/create-digital-human. Include optional fields that serve the goal of setting up for testing and monitoring on Bluejay.
 
 ### Example

--- a/api-reference/endpoint/update-digital-human.mdx
+++ b/api-reference/endpoint/update-digital-human.mdx
@@ -114,6 +114,8 @@ Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpo
 }
 ```
 
+> **Note:** `endpointing_delay` is referenced as **patience** in the UI. It controls how long (in seconds) the digital human waits after silence before assuming the speaker has finished talking.
+
 ### Example
 **PUT with body:**
 ```python


### PR DESCRIPTION
## Summary
- Added a note to the Create Digital Human and Update Digital Human API reference docs clarifying that `endpointing_delay` is referenced as **patience** in the UI
- Fixes confusion raised by a customer (Nick Busey) in #bluejay-wonderly on 2026-03-30 who discovered the mismatch between the UI label and the API field name

## Test plan
- [ ] Verify the note renders correctly on both create and update digital human doc pages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that `endpointing_delay` is labeled as “patience” in the UI in the Create and Update Digital Human API docs, and explains it controls how many seconds the digital human waits after silence before assuming the speaker is done. This aligns the API docs with the UI to reduce confusion.

<sup>Written for commit 0624a8894105da8a226066e0c2a8a9848aa87175. Summary will update on new commits. <a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/184?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

