### PR TITLE
Dev

### DIFF
--- a/api-reference/endpoint/create-digital-human.mdx
+++ b/api-reference/endpoint/create-digital-human.mdx
@@ -112,6 +112,8 @@ Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpo
 }
 ```
 
+> **Note:** `endpointing_delay` is referenced as **patience** in the UI. It controls how long (in seconds) the digital human waits after silence before assuming the speaker has finished talking.
+
 Refer to the full schema at https://docs.getbluejay.ai/api-reference/endpoint/create-digital-human. Include optional fields that serve the goal of setting up for testing and monitoring on Bluejay.
 
 ### Example

--- a/api-reference/endpoint/update-digital-human.mdx
+++ b/api-reference/endpoint/update-digital-human.mdx
@@ -114,6 +114,8 @@ Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpo
 }
 ```
 
+> **Note:** `endpointing_delay` is referenced as **patience** in the UI. It controls how long (in seconds) the digital human waits after silence before assuming the speaker has finished talking.
+
 ### Example
 **PUT with body:**
 ```python


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the API docs for create/update Digital Human endpoints by noting that `endpointing_delay` appears as “patience” in the UI and sets how many seconds of silence end a turn. This reduces confusion between API and UI naming.

<sup>Written for commit fd9ae817605ba1ebd1c2fe4e0d4d05514648791d. Summary will update on new commits. <a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/185?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

