### PR TITLE
Add prompting guides for Digital Humans and Custom Metrics

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -77,6 +77,7 @@
                 "pages": [
                   "key-concepts/digital-humans/overview",
                   "key-concepts/digital-humans/configuration",
+                  "key-concepts/digital-humans/prompting-guide",
                   "key-concepts/digital-humans/use-cases",
                   "core-concepts/digital-humans"
                 ]
@@ -88,6 +89,7 @@
                 "pages": [
                   "key-concepts/custom-metrics/overview",
                   "key-concepts/custom-metrics/metric-types",
+                  "key-concepts/custom-metrics/prompting-guide",
                   "key-concepts/custom-metrics/dynamic-variables"
                 ]
               },

--- a/key-concepts/custom-metrics/prompting-guide.mdx
+++ b/key-concepts/custom-metrics/prompting-guide.mdx
@@ -1,0 +1,338 @@
+---
+title: Prompting Guide
+description: Best practices for writing Custom Metric prompts that produce reliable, predictable evaluations
+icon: pen-fancy
+---
+
+A Custom Metric is a verifier. It either confirms that an agent or customer took an action on the call, or it rates, ranks, or classifies what they did. Because the verdict drives what your team trusts, the prompt that defines it has to be written clearly.
+
+The biggest payoff of a well-written metric is predictable evaluations. When the prompt is precise, the verdict matches what your team would have said reading the transcript or listening to the audio. When the prompt is loose, the model has no solid definition of success and the verdict becomes non-deterministic. The same call returns different scores on different runs.
+
+<Tip>
+A good metric returns the verdict you would have given yourself reviewing the call. If your gut and the metric disagree, the prompt is the problem, not the model. Tighten the wording or add the missing piece of evidence.
+</Tip>
+
+## Core Principles
+
+<CardGroup cols={3}>
+  <Card title="Anchor to evidence in the transcript" icon="anchor">
+    Every criterion should be answerable from the words on the page. If a human reading the transcript cannot tell, the model cannot tell either.
+  </Card>
+  <Card title="Define the output shape" icon="brackets-curly">
+    Spell out exactly what the response should look like: labels, ranges, JSON keys, or text constraints. The shape is half the prompt.
+  </Card>
+  <Card title="One thing per metric" icon="bullseye">
+    A metric should answer one thing you want to know. If you would care about each result independently, write separate metrics.
+  </Card>
+</CardGroup>
+
+## Prompting by Metric Type
+
+Each response type does a different job, so each one rewards a different prompting style. Pick the tab that matches the metric you are writing.
+
+<Tabs>
+  <Tab title="Pass / Fail">
+    A Pass / Fail metric is an assertion. State the conditions that make the metric pass and the conditions that make it fail.
+
+    **Good prompt**
+
+    ```
+    The metric passes if the agent verified the customer's identity by
+    asking for at least two of: full name, date of birth, last four
+    digits of the card, or billing ZIP code, BEFORE sharing any account
+    details.
+
+    The metric fails if fewer than two were requested, or if account
+    details were shared first.
+
+    Example pass: agent asked for date of birth and last four, then
+    quoted the balance.
+    Example fail: agent quoted the balance after only confirming the
+    customer's name.
+    ```
+
+    **Bad prompt**
+
+    ```
+    Did the agent verify and help the customer well during the call?
+    ```
+
+    The good version names the pass condition, the fail condition, and gives one example of each. The bad version stacks two behaviors and leans on an undefined word.
+
+    **Common Pass / Fail mistakes**
+
+    **Stacking independent behaviors.** A Pass / Fail metric should test one thing you want to know. If verifying identity and issuing a refund are two outcomes you would care about independently, write two metrics. If they only matter as a joint result (the call is a fail unless both happened), one metric is fine.
+
+    **Vague pass criteria.** "The agent did the right thing" leaves the definition to the model. Replace it with the specific behavior you would look for in the transcript.
+
+    **Describing what the agent should do, not what the metric verifies.** The prompt grades the call. Phrases like "the agent should be polite" belong in the agent's instructions, not in a metric.
+
+    <Tip>
+    If the prompt reaches for words like "good," "appropriate," or "well," you are leaving the definition to the model. Replace those words with specific, observable evidence.
+    </Tip>
+
+    **Dynamic variables**
+
+    Use dynamic variables to make the pass criteria call-specific.
+
+    ```
+    The metric passes if the agent confirmed the order for {{customer_name}}
+    matched the items in {{order_summary}}.
+    ```
+
+    See [Dynamic Variables](/key-concepts/custom-metrics/dynamic-variables) for the full setup.
+  </Tab>
+  <Tab title="Quantitative">
+    A quantitative metric is a rubric. Define every level on the scale so the judge has anchors to grade against.
+
+    **Good prompt**
+
+    ```
+    Rate the agent's clarity of explanation from 1 to 5.
+
+    1 = Confusing. The customer would not be able to act on the explanation.
+    2 = Partial. Key terms were used without definition.
+    3 = Adequate. The customer could likely act, but had to infer some steps.
+    4 = Clear. Steps were named and ordered.
+    5 = Exceptional. Steps were named, ordered, and confirmed back with
+        the customer.
+    ```
+
+    **Bad prompt**
+
+    ```
+    Rate the clarity from 1 to 10 where 1 is bad and 10 is good.
+    ```
+
+    A 1-to-10 scale with no anchors returns a 4 on one call and an 8 on a near-identical one. A 1-to-5 scale with anchored levels stays stable.
+
+    **Common quantitative mistakes**
+
+    **Unanchored scales.** Without a definition for each value, the model invents its own scale and your scores drift across runs.
+
+    **Too many levels.** Models reliably distinguish about five levels. Ten or a hundred sound precise but produce more noise than signal.
+
+    **Vague endpoints.** "1 is bad, 5 is good" tells the judge nothing. Anchor 1 and 5 to observable behaviors so the middle values land in predictable places.
+
+    **Dynamic variables**
+
+    Inject call-specific anchors when the rubric depends on facts that change per call.
+
+    ```
+    Rate how thoroughly the agent explained the {{plan_name}} plan from 1 to 5.
+    ```
+
+    See [Dynamic Variables](/key-concepts/custom-metrics/dynamic-variables).
+  </Tab>
+  <Tab title="Qualitative">
+    A qualitative metric returns free text. The trick is to constrain the structure so the outputs stay comparable across calls.
+
+    **Good prompt**
+
+    ```
+    Summarize how the agent handled customer objections.
+
+    Include:
+    1. The objections the customer raised, in the order they were raised.
+    2. The agent's response to each, quoted briefly.
+    3. Whether the response resolved the objection (yes, partial, no).
+
+    Keep the response under 120 words.
+    ```
+
+    **Bad prompt**
+
+    ```
+    Tell me how the call went. Be detailed.
+    ```
+
+    Free-text answers are useful only when their structure is fixed. Otherwise comparing them across calls is impossible.
+
+    **Common qualitative mistakes**
+
+    **No structure.** "Tell me about the call" produces a different summary every run. Numbered sections or required fields fix the shape.
+
+    **No length cap.** Without a word limit, summaries balloon and stop being skimmable. 100 to 150 words is usually plenty.
+
+    **Asking for opinions instead of observations.** "How do you feel about the agent's tone" is unfalsifiable. "Quote the phrase the agent used to acknowledge the customer's frustration" is observable.
+
+    **Dynamic variables**
+
+    Inject the topic the summary should focus on.
+
+    ```
+    Summarize how the agent handled the customer's question about {{topic}}.
+    ```
+
+    See [Dynamic Variables](/key-concepts/custom-metrics/dynamic-variables).
+  </Tab>
+  <Tab title="Enum">
+    An enum metric is a multi-class classifier. Define the attributes that put a call into one class versus another. The judge needs to know what evidence makes a call a member of each class.
+
+    **Good prompt**
+
+    ```
+    Classify this fast-food call into exactly one category.
+
+    - new_order: The customer is placing an order they have not placed before.
+    - modify_order: The customer is changing or adding to an order already placed.
+    - order_status: The customer is asking where their existing order is or
+      when it will be ready.
+    - complaint: The customer is reporting a problem with an order, the food,
+      or the service.
+    - general_inquiry: The customer is asking about hours, locations, menu items,
+      or pricing without placing or modifying an order.
+
+    If two categories apply (for example, a complaint that turns into a new
+    order), pick the category that occupied the most call time.
+    ```
+
+    **Bad prompt**
+
+    ```
+    What kind of call is this? new_order, modify_order, order_status,
+    complaint, or general_inquiry?
+    ```
+
+    The bad version names the labels but defines none of them. Calls land in different buckets across runs.
+
+    **Common enum mistakes**
+
+    **Labels without definitions.** "Resolved, escalated, callback_scheduled" looks self-explanatory and is not. Spell out the evidence that puts a call in each bucket.
+
+    **No tiebreaker.** Real calls overlap. State a single rule the judge follows when more than one label could apply.
+
+    **Too many classes.** Beyond seven or eight categories, the model starts to blend boundaries. Collapse rare labels into an "other" bucket if you need to.
+
+    **Dynamic variables**
+
+    Inject classification context when the right label depends on facts the judge cannot infer from the transcript alone.
+
+    ```
+    Classify the call. The customer's stated reason for calling was: {{stated_reason}}.
+    ```
+
+    See [Dynamic Variables](/key-concepts/custom-metrics/dynamic-variables).
+  </Tab>
+  <Tab title="JSON">
+    A JSON metric is a typed contract. The schema you define is what the model has to return. Specify keys, types, and what counts as evidence for each.
+
+    **Good prompt**
+
+    ```
+    Evaluate the call and return a JSON object with exactly these keys:
+
+    - identity_verified (boolean): true if the agent verified identity using
+      at least two factors before sharing account details.
+    - disclosure_read (boolean): true if the recording disclosure was read
+      within the first 15 seconds of the call.
+    - consent_obtained (boolean): true if the agent received explicit verbal
+      consent before any account change.
+    - flags (string[]): a short string for each compliance issue you found.
+      Empty array if there were none.
+
+    Return only the JSON object. Do not include any other text.
+    ```
+
+    **Bad prompt**
+
+    ```
+    Return JSON about whether the call was compliant.
+    ```
+
+    Specify the keys, the types, and what counts as evidence for each one. The "return only the JSON object" line is what stops the model from adding a friendly preamble.
+
+    **Common JSON mistakes**
+
+    **Keys without types.** A field called `verified` could be a boolean, a string, or an enum. State the type so the schema stays stable across runs.
+
+    **No "return only the JSON" instruction.** Without it, the model often adds a friendly sentence before or after the object and your downstream parser breaks.
+
+    **Fuzzy field descriptions.** "Issues found" is vague. "Each issue as a short sentence describing what was missed and where in the call" tells the judge what to put in the field.
+
+    **Dynamic variables**
+
+    Inject required context into a key's definition.
+
+    ```
+    verify_id (boolean): true if the agent verified the customer using at
+    least these factors: {{required_factors}}.
+    ```
+
+    See [Dynamic Variables](/key-concepts/custom-metrics/dynamic-variables).
+  </Tab>
+</Tabs>
+
+## Using Dynamic Variables
+
+Dynamic variables let you inject call-specific values into a metric prompt at evaluation time. You write `{{customer_name}}` or `{{plan_price}}` in the prompt, pass the matching keys in the `metadata` object on the evaluate request, and Bluejay substitutes them before the judge runs.
+
+This pattern matters when the right answer depends on facts that change per call: the customer's name, the plan they are on, the order ID, the expected balance. Without dynamic variables you would need a separate metric for every value. With them, you keep one metric and pass the values per call.
+
+<Note>
+Dynamic variables work in any response type. The substitution happens before the judge sees the prompt, so anything you can write as plain text can be parameterized.
+</Note>
+
+For the full setup and the request-payload format, see [Dynamic Variables](/key-concepts/custom-metrics/dynamic-variables).
+
+## Tuning Metrics in the Metrics Lab
+
+Sometimes a metric is close but not quite right. The pass rate is too generous, or it flags borderline cases your team would have let through. You have two paths.
+
+<CardGroup cols={2}>
+  <Card title="Edit the prompt by hand" icon="pen">
+    Add a clarifying sentence, run it against a few sample calls, and check whether the new outputs match your judgment. Fast for small adjustments.
+  </Card>
+  <Card title="Tune with human feedback" icon="flask" href="/key-concepts/metrics-lab/overview">
+    For metrics that need to encode your team's specific standards, use the Metrics Lab. You annotate calls, the Lab tunes the metric to match your annotations.
+  </Card>
+</CardGroup>
+
+The second path is an application of Reinforcement Learning from Human Feedback (RLHF), the technique behind most modern AI assistants. A person rates the model's output, and the system updates so future outputs match what the person preferred. The Metrics Lab applies that idea to a single Custom Metric.
+
+### Walkthrough
+
+<Steps>
+  <Step title="Pick a representative sample">
+    Twenty to fifty calls. Cover obvious passes, obvious fails, and the ambiguous middle.
+  </Step>
+  <Step title="Annotate each call">
+    Mark the outcome you believe is correct: pass or fail, the right label, the right score.
+  </Step>
+  <Step title="Run alignment">
+    The Lab compares your annotations to the AI's verdicts and tunes the metric to close the gap.
+  </Step>
+  <Step title="Validate on a holdout">
+    Run the tuned metric against a small set you did not annotate. If the verdicts match yours, the metric is ready.
+  </Step>
+  <Step title="Promote to production">
+    Push the tuned metric to your simulations and live monitoring.
+  </Step>
+</Steps>
+
+For a deeper look at how alignment works, see the [Metrics Lab overview](/key-concepts/metrics-lab/overview).
+
+## Checklist
+
+Before saving a Custom Metric, run through this list.
+
+- The metric tests one thing you want to know.
+- Every criterion is answerable from the transcript or audio.
+- For Pass / Fail, the pass and fail conditions are explicit.
+- For graded metrics, every level on the scale is anchored.
+- For enums, every label has a definition and a tiebreaker rule.
+- For JSON, every key has a type and a definition.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Metric Types" icon="shapes" href="/key-concepts/custom-metrics/metric-types">
+    Refresh on the response types and when to use each.
+  </Card>
+  <Card title="Dynamic Variables" icon="brackets-curly" href="/key-concepts/custom-metrics/dynamic-variables">
+    The full reference for parameterizing prompts at evaluation time.
+  </Card>
+  <Card title="Metrics Lab" icon="flask" href="/key-concepts/metrics-lab/overview">
+    Tune metrics against human-annotated calls using agent alignment.
+  </Card>
+</CardGroup>

--- a/key-concepts/digital-humans/prompting-guide.mdx
+++ b/key-concepts/digital-humans/prompting-guide.mdx
@@ -1,0 +1,163 @@
+---
+title: Prompting Guide
+description: Best practices for writing Digital Human intents and success criteria
+icon: pen-fancy
+---
+
+A Digital Human is a test case for your agent. The intent is the input, the success criteria are the assertion, and the wording you give both is what the model uses to play the customer and to grade the call afterward.
+
+The biggest payoff of a well-written prompt is instruction following. When the intent is precise, the Digital Human navigates the IVR you wanted it to navigate, asks the question you wanted it to ask, and walks away when it should walk away. Loose intents leave room for the model to improvise, and an improvising Digital Human stops testing the thing you wrote it to test.
+
+## Treat Digital Humans Like Test Cases
+
+Every Digital Human is a unit test against your agent. Treat the intent the way you would treat the input to a unit test: name the actions, list the facts the agent will need, and stop. The more general the intent, the more freedom the model has on the call, and the more your test starts measuring the model's creativity instead of your agent's behavior.
+
+Tighten the intent when you want a deterministic test. Keep it general when you want broad coverage, and accept that the trade-off is verifiability.
+
+<Tip>
+Treat the trait fields as your fixtures. Account numbers, member IDs, names, and order details belong there rather than buried in the intent prose. The agent has a single place to look, and you can swap fixtures without rewriting the intent.
+</Tip>
+
+## Core Principles
+
+<CardGroup cols={3}>
+  <Card title="Write instructions the model can follow" icon="list-check">
+    State the actions you want the Digital Human to take, in the order you want them taken. Anything you do not specify, the model fills in on its own.
+  </Card>
+  <Card title="Anchor actions to moments in the call" icon="anchor">
+    Tie behavior to specific points in the conversation. "When the agent asks for a customer ID, say you do not have one" produces a deterministic call.
+  </Card>
+  <Card title="Match specificity to the test" icon="bullseye">
+    Specific intents grade cleanly and run consistently. General intents give coverage at the cost of verifiability.
+  </Card>
+</CardGroup>
+
+## Writing Intents
+
+A good intent describes the actions the Digital Human takes during the call. The easier those actions are to verify from a transcript, the better the intent. Length is not the goal. A two-sentence intent that names a clear sequence of actions beats a five-paragraph backstory every time.
+
+<Check>
+**Good intents** describe verifiable actions:
+
+- Order a cheeseburger with no onions and a small drink for pickup at the closest location.
+- Navigate the IVR to retrieve the balance on your checking account ending in 4821.
+- Call in to refill a prescription you placed last week. When the agent asks for a customer ID, say you do not have one.
+
+A reader can look at a transcript and tell whether each action took place.
+</Check>
+
+<Warning>
+**Bad intent:** _"The customer calls in and answers all the agent's questions correctly."_
+
+The word "correctly" is doing the entire job, and it is undefined. The model running the Digital Human has its own definition of correct, your team has another, and they will not line up.
+</Warning>
+
+<Tip>
+If you reach for a word like "correctly," "appropriately," or "successfully" in an intent, you are usually describing what the agent should do. Move that idea to the success criteria and rewrite the intent in terms of the Digital Human's actions.
+</Tip>
+
+### Common intent mistakes
+
+**Not providing enough information.** A Digital Human can only act on what you tell it. If the call requires an account number, a date of birth, an order ID, or an address, include it in the intent or the trait fields. Without that information, the call fails for reasons that have nothing to do with your agent.
+
+**Describing your agent's behavior inside the intent.** The intent is the script for the Digital Human. Lines like "the agent should ask for verification" belong in the success criteria. When you mix the two, the model occasionally tries to play both sides of the call, and the Digital Human starts coaching the agent toward the right answer.
+
+**Providing conflicting information.** If the intent says the customer is calling about a dog and then later refers to a cat, the model picks one and may switch mid-call. Keep the facts consistent across the intent and the trait fields.
+
+**Providing incomplete information.** If a successful call requires the Digital Human to provide a member ID, make sure the Digital Human has one. The same goes for order numbers, prescription IDs, and verification details. Without the data the agent will ask for, the call dead-ends before your agent gets a chance to demonstrate the behavior you wanted to test.
+
+## Writing Success Criteria
+
+A success criterion is good when it is verifiable from the transcript and scoped to exactly what you care about.
+
+<Check>
+**Good success criteria** are verifiable facts:
+
+- The agent books the appointment for the customer and provides a confirmation of the booking.
+- The agent refuses to provide assistance to a customer who cannot provide a valid member ID.
+
+Both can be confirmed by reading the transcript. Neither asks the evaluator to define a fuzzy word like "good" or "right."
+</Check>
+
+### Common success criteria mistakes
+
+**Too vague.** _"The agent does the right thing in the conversation."_ The definition of "right" lives in your head. The model uses its own definition. Pass rates drift away from what your team would have said.
+
+**Over-scoped.** _"The agent books the appointment, notifies the customer that the appointment was booked, and asks if they have any other questions."_ If the only thing you cared about was whether the appointment was booked, the second and third clauses are an overreach. The criterion now fails any call where the agent booked the appointment cleanly but skipped the trailing question. Scope the criterion to exactly what matters and no more.
+
+**Stacking unrelated outcomes.** If you genuinely care about more than one outcome, split them into separate Custom Metrics. One failure will not mask the others, and your dashboard will tell you which behavior actually broke.
+
+## Examples Across Industries
+
+<Tabs>
+  <Tab title="Healthcare">
+    **Scenario:** Prescription refill without a customer ID.
+
+    **Intent**
+
+    > You are calling to check the status of a prescription refill you placed last week. When the agent asks for your customer ID, say you do not have one and have never been issued one.
+
+    **Success Criteria**
+
+    > The agent declined to provide service or look up the order without a valid customer ID.
+  </Tab>
+  <Tab title="Restaurant Services">
+    **Scenario:** Reservation for Friday night.
+
+    **Intent**
+
+    > You are calling to book a table for four at 7:30 PM this Friday under the name Jordan Lee. If 7:30 PM is unavailable, accept any time within thirty minutes of that slot.
+
+    **Success Criteria**
+
+    > The agent confirmed a reservation for four people for this Friday within thirty minutes of 7:30 PM under the name Jordan Lee.
+  </Tab>
+  <Tab title="Food">
+    **Scenario:** Cheeseburger pickup order.
+
+    **Intent**
+
+    > You are calling the closest location to place a pickup order. You want one cheeseburger with no onions and a small fountain drink. You will pay at the counter when you arrive.
+
+    **Success Criteria**
+
+    > The agent confirmed an order of one cheeseburger with no onions and one small fountain drink, and quoted a pickup time.
+  </Tab>
+  <Tab title="Telecom">
+    **Scenario:** Billing dispute over a \$60 overcharge.
+
+    **Intent**
+
+    > You were charged \$189 on your last bill instead of the usual \$129. You want the \$60 difference refunded to the original payment method. If a refund is not possible, accept an account credit for the same amount.
+
+    **Success Criteria**
+
+    > The agent acknowledged the \$60 overcharge and either refunded the \$60 to the original payment method, issued an account credit for the same amount, or escalated the request to a team that could.
+  </Tab>
+</Tabs>
+
+<Tip>
+Once an intent works, drop it into a Community. The same Digital Human becomes a regression test you can rerun on every agent version, so a fix in one release does not silently regress in the next.
+</Tip>
+
+## Checklist
+
+Before saving a Digital Human, run through this list.
+
+- The intent describes the actions the Digital Human takes during the call.
+- Every piece of information the agent will ask for is present in the intent or traits.
+- The intent does not describe what the agent should do.
+- The intent does not contain contradictions.
+- Each success criterion is verifiable from a transcript.
+- Each success criterion captures exactly what you care about and nothing more.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Configuration" icon="gear" href="/key-concepts/digital-humans/configuration">
+    Pair a strong prompt with the right voice, language, and call-flow configuration.
+  </Card>
+  <Card title="Custom Metrics Prompting" icon="pen-fancy" href="/key-concepts/custom-metrics/prompting-guide">
+    Apply the same principles to the LLM-as-a-Judge prompts that score your calls.
+  </Card>
+</CardGroup>

--- a/key-concepts/metrics-lab/overview.mdx
+++ b/key-concepts/metrics-lab/overview.mdx
@@ -1,54 +1,115 @@
 ---
 title: Overview
-description: Understand how Metrics Lab fits into Bluejay evaluation workflows
+description: Align your AI evaluations with human-annotated outcomes using agent alignment in the Metrics Lab
 icon: flask
 ---
 
-Metrics Lab is the experimental layer where teams define, test, and refine what they want Bluejay to measure. It helps turn evaluation design into an intentional, iterative process.
+The Metrics Lab is where you teach Bluejay's evaluator to grade calls the way your team would. You annotate a representative set of calls with the outcome you believe is correct, and Bluejay tunes your Custom Metric so that its verdicts on future calls match the verdicts you would have given. This process is called **agent alignment**, and it is a practical application of reinforcement learning from human feedback (RLHF).
 
 ## What You'll Learn
 
-- What Metrics Lab is and when to use it
-- How to prototype and test evaluation prompts
-- How to promote metrics from experimentation to production
+- What agent alignment is and why it matters
+- How human annotations shape the metric's future evaluations
+- When to use the Metrics Lab
+- How to run an alignment cycle end to end
 
-## How Metrics Lab Works
+## The Idea in One Paragraph
 
-You use Metrics Lab to prototype measurement ideas, compare scoring approaches, and mature Custom Metrics before you depend on them across simulations, alerts, and reporting workflows.
+Take a representative subset of your calls. Annotate each one with the outcome a human reviewer believes is correct. Bluejay then adjusts your Custom Metric so that its AI evaluations on that subset match your human annotations. If the subset is representative of the calls your agent handles, the tuned metric will generalize, returning verdicts on new calls that line up with how your team would grade them.
+
+## How Agent Alignment Works
 
 ```mermaid
-flowchart LR
-    Draft[Draft/Import Custom Metrics + Conversations] --> Annotate[Human-Annotate Conversations]
-    Annotate --> Test[Test Metrics Against Conversations]
-    Test --> Refine[Refine Scoring Logic, Optimize for Alignment]
-    Refine --> Test
-    Refine --> Promote[Promote to Production]
-    Promote --> Sim[Simulations]
-    Promote --> Obs[Observability]
+flowchart TD
+    Calls[Pick a representative sample of calls] --> Annotate[Human annotates each call with the correct outcome]
+    Annotate --> Compare[Compare AI evaluations to human annotations]
+    Compare --> Gap{Verdicts match?}
+    Gap -->|No| Tune[Tune the metric prompt and scoring logic]
+    Tune --> Compare
+    Gap -->|Yes| Promote[Promote the aligned metric to production]
+    Promote --> Generalize[Aligned metric grades new calls the way your team would]
 ```
 
-Metrics Lab provides an interactive environment where you write evaluation prompts, test them against sample transcripts, and iterate on scoring criteria. Once a metric performs reliably, you promote it to production where it runs automatically across simulations and observability evaluations.
+The loop is the part that does the work. Each pass, Bluejay closes the distance between the AI's verdict and the human's verdict. When the two agree across the sample, the metric is ready to leave the Lab.
 
-## Key Capabilities
+### Why a Subset Generalizes
 
-- **Interactive prototyping** -- write and test evaluation prompts against sample transcripts in real time
-- **Side-by-side comparison** -- compare different scoring approaches to find the most reliable one
-- **Safe experimentation** -- iterate without affecting production data or live evaluations
-- **One-click promotion** -- move a validated metric directly into your simulation and observability workflows
+Every alignment system rests on one assumption: the calls you annotate are a fair cross-section of the calls you actually receive. If your sample covers the scenarios that occur in production, including the borderline cases, then a metric tuned to match human verdicts on that sample will continue to match them on new calls. If your sample is skewed, the tuning will be skewed too.
 
-## Common Use Cases
+A short rule of thumb when you build the sample:
 
-- Draft a new "compliance check" metric and test it against 10 sample transcripts before deploying
-- Compare two different prompts for scoring empathy to see which produces more consistent results
-- Validate that a formula metric correctly computes a composite score before attaching it to alerts
+- Include obvious passes and obvious fails so the metric has clear anchors.
+- Include the ambiguous middle, because that is where the AI and humans disagree most often.
+- Cover each Digital Human intent or production scenario that you care about.
+
+### Where RLHF Fits In
+
+Reinforcement learning from human feedback is the family of techniques that powers most modern AI assistants. The recipe is always the same: a model produces an output, a person rates it, and the system updates so that future outputs look more like what the person preferred. Agent alignment is the same idea applied to a single Custom Metric. The "model" is the metric. The "rating" is your annotation. The "update" is the metric tuning that the Lab runs for you.
+
+## What You Get Out of It
+
+<CardGroup cols={2}>
+  <Card title="Evaluations you trust" icon="circle-check">
+    The metric grades calls the way your team would, so the dashboard reflects reality and not a generic LLM's intuition.
+  </Card>
+  <Card title="Faster iteration" icon="bolt">
+    Instead of rewriting the prompt by hand and guessing at the right phrasing, you annotate calls and let the Lab close the gap.
+  </Card>
+  <Card title="Defensible standards" icon="scale-balanced">
+    Your alignment set is a record of how your team grades calls. New hires can review it. Auditors can review it. The standard lives somewhere concrete.
+  </Card>
+  <Card title="Continuous improvement" icon="arrows-rotate">
+    Add new annotations as edge cases come up. Re-run alignment. The metric stays in lockstep with how your team thinks about quality.
+  </Card>
+</CardGroup>
+
+## When to Use the Metrics Lab
+
+- A metric is close, but its pass rate disagrees with your team's gut on borderline calls.
+- You want a metric that encodes your team's specific standards rather than a generic definition.
+- A new edge case has appeared in production and the existing metric mishandles it.
+- You are launching a new metric and want to validate it against real annotated data before depending on it.
+
+## A Walkthrough
+
+<Steps>
+  <Step title="Pick a representative sample">
+    Pull twenty to fifty calls that cover the full range of behaviors you care about. Include obvious passes, obvious fails, and the ambiguous middle.
+  </Step>
+  <Step title="Annotate each call">
+    For every call, mark the outcome you believe is correct. For a Pass / Fail metric, that is pass or fail. For an enum, the right label. For a quantitative metric, the score.
+  </Step>
+  <Step title="Run alignment">
+    Bluejay compares the metric's AI evaluations on the sample to your annotations and tunes the metric to close the gap.
+  </Step>
+  <Step title="Validate on a holdout">
+    Run the tuned metric against a handful of calls you did not annotate. If the verdicts match what you would have said, the metric is ready.
+  </Step>
+  <Step title="Promote to production">
+    Push the aligned metric out to your simulations and live monitoring. New calls will be graded the way your team would grade them.
+  </Step>
+</Steps>
+
+## A Worked Analysis
+
+Imagine a Pass / Fail metric for "Identity Verified Before Sharing Account Details." Out of the box, the AI is generous: it passes calls where the agent confirmed only a name, even when policy requires two factors.
+
+You annotate fifty calls. Twenty are clear passes (two factors confirmed). Twenty are clear fails (no verification at all). Ten are borderline: the agent confirmed one factor and the customer volunteered another. Your team's policy says the agent must explicitly request both, so you mark all ten as fail.
+
+You run alignment. The Lab observes the gap on the borderline cases and tightens the metric so that "agent explicitly requested two factors" is the threshold. On the validation set, the AI now fails the borderline calls just like you did. Promoted to production, the metric flags the same gap consistently across thousands of calls, with verdicts that match what your team would have said.
+
+This is the value of agent alignment in one example: a metric that is close becomes a metric that is right.
 
 ## Next Steps
 
 <CardGroup cols={2}>
   <Card title="Custom Metrics" icon="gauge-high" href="/key-concepts/custom-metrics/overview">
-    Learn about the metrics that Metrics Lab helps you create.
+    Understand the metrics that the Lab tunes.
   </Card>
-  <Card title="Create Custom Metrics API" icon="code" href="/api-reference/endpoint/create-custom-metrics">
-    Create metrics programmatically via the API.
+  <Card title="Custom Metrics Prompting Guide" icon="pen-fancy" href="/key-concepts/custom-metrics/prompting-guide">
+    Learn the prompt patterns that make alignment converge faster.
+  </Card>
+  <Card title="Create Custom Metric API" icon="code" href="/api-reference/endpoint/create-custom-metric">
+    Define a metric programmatically before bringing it into the Lab.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- New **Digital Humans Prompting Guide** covering intents, success criteria, common mistakes, and per-industry examples (healthcare, restaurant, food, telecom).
- New **Custom Metrics Prompting Guide** with per-type prompting strategies (Pass / Fail, Quantitative, Qualitative, Enum, JSON), per-type common mistakes, dynamic-variable seeding inside every tab, and a Metrics Lab tuning walkthrough.
- **Metrics Lab overview** rewritten around agent alignment and RLHF, with a new mermaid loop diagram and a worked analysis.
- Both new guides wired into the Key Concepts navigation.

## Test plan
- [ ] Verify both new pages render correctly in Mintlify preview.
- [ ] Confirm Tabs, CardGroup, Check, Warning, Tip, and Steps components render as expected.
- [ ] Confirm dollar signs in the Telecom example escape correctly (no LaTeX collapse).
- [ ] Spot-check internal links: prompting-guide ↔ Metrics Lab ↔ Dynamic Variables.
- [ ] Confirm sidebar ordering under Digital Humans and Custom Metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two new prompting guides (Digital Humans and Custom Metrics) and rewrites the Metrics Lab overview around agent alignment and RLHF. Updates navigation to surface the new pages.

- **New Guides and Docs Updates**
  - Digital Humans Prompting Guide: clear intents, verifiable success criteria, common mistakes, and examples for healthcare, restaurant, food, and telecom.
  - Custom Metrics Prompting Guide: prompting patterns per type (Pass/Fail, Quantitative, Qualitative, Enum, JSON), per-type pitfalls, dynamic-variable seeding, and a Metrics Lab tuning walkthrough.
  - Metrics Lab overview: reframed around agent alignment with a loop diagram and a worked analysis.
  - Navigation: added `key-concepts/digital-humans/prompting-guide` and `key-concepts/custom-metrics/prompting-guide` in `docs.json`.

<sup>Written for commit 9f4876b94125dd1aec7260add73c40caf27bf96d. Summary will update on new commits. <a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/187?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

