### PR TITLE
Dev

### DIFF
--- a/api-reference/endpoint/pull-bluejay-as-code.mdx
+++ b/api-reference/endpoint/pull-bluejay-as-code.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Pull Bluejay as Code"
-openapi: "GET /v1/bluejay-as-code/simulation/{simulation_bluejay_id}"
+openapi: "GET /v1/bluejay-as-code/{root_type}/{root_id}"
 ---
 <div className="ai-prompt-box">
 <div className="ai-prompt-box-header">Integration Prompt for AI Agents</div>
@@ -9,18 +9,19 @@ openapi: "GET /v1/bluejay-as-code/simulation/{simulation_bluejay_id}"
 
 You are a senior backend engineer integrating the Bluejay API. Think step-by-step: first understand the endpoint, then plan the integration, then implement with minimal changes.
 
-## Pull Bluejay as Code — GET /v1/bluejay-as-code/simulation/{simulation_bluejay_id}
+## Pull Bluejay as Code — GET /v1/bluejay-as-code/{root_type}/{root_id}
 
-> **What this endpoint does:** Export a simulation's full configuration as a JSON payload. Returns the simulation, its agent, all linked digital humans, and all associated custom metrics — each with their `bluejay_as_code_id` populated. Use this payload as the starting point for version-controlled config management.
+> **What this endpoint does:** Export a Bluejay configuration as a JSON payload, rooted at any of four entity types. The simulation root (`/v1/bluejay-as-code/simulation/{id}`) is the most common — it returns the simulation, its agent, all linked digital humans, and all associated custom metrics, each with `bluejay_as_code_id` populated. Use this payload as the starting point for version-controlled config management.
 
-**Endpoint:** GET `https://api.getbluejay.ai/v1/bluejay-as-code/simulation/{simulation_bluejay_id}`
+**Endpoint:** GET `https://api.getbluejay.ai/v1/bluejay-as-code/{root_type}/{root_id}`
 **Auth:** `X-API-Key` header
 
 ### Required Parameters
 | Name | Type | Description |
 |------|------|-------------|
 | X-API-Key | string | API key required to authenticate requests. |
-| simulation_bluejay_id | string (path) | The ID of the simulation to export. |
+| root_type | string (path) | One of `simulation`, `agent`, `digital-human`, `custom-metric`. Determines which entity anchors the bundle. |
+| root_id | string (path) | The Bluejay ID (or `bluejay_as_code_id` UUID) of the root entity to export. |
 
 Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpoint/pull-bluejay-as-code.
 
@@ -39,6 +40,8 @@ Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpo
 import requests
 
 def pull_bluejay_as_code(simulation_id: str, api_key: str) -> dict:
+    # Most integrations anchor on a simulation. You can also use root_type
+    # "agent", "digital-human", or "custom-metric" to anchor on those entities.
     url = f"https://api.getbluejay.ai/v1/bluejay-as-code/simulation/{simulation_id}"
     headers = {"X-API-Key": api_key}
     response = requests.get(url, headers=headers)

--- a/api-reference/endpoint/push-bluejay-as-code.mdx
+++ b/api-reference/endpoint/push-bluejay-as-code.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Push Bluejay as Code"
-openapi: "POST /v1/bluejay-as-code/simulation"
+openapi: "POST /v1/bluejay-as-code"
 ---
 <div className="ai-prompt-box">
 <div className="ai-prompt-box-header">Integration Prompt for AI Agents</div>
@@ -9,11 +9,11 @@ openapi: "POST /v1/bluejay-as-code/simulation"
 
 You are a senior backend engineer integrating the Bluejay API. Think step-by-step: first understand the endpoint, then plan the integration, then implement with minimal changes.
 
-## Push Bluejay as Code — POST /v1/bluejay-as-code/simulation
+## Push Bluejay as Code — POST /v1/bluejay-as-code
 
-> **What this endpoint does:** Apply a Bluejay as Code payload to Bluejay. Each entity in the payload is matched by its `bluejay_as_code_id` — created if not found, updated if fields changed, left untouched if identical. Returns a list of actions taken and any validation errors.
+> **What this endpoint does:** Apply a Bluejay as Code payload to Bluejay. Each entity in the payload is matched by its `bluejay_as_code_id` — created if not found, updated if fields changed, left untouched if identical. Returns a list of actions taken (as human-readable strings), any validation errors, and the resolved `simulation_id` of the simulation in the bundle.
 
-**Endpoint:** POST `https://api.getbluejay.ai/v1/bluejay-as-code/simulation`
+**Endpoint:** POST `https://api.getbluejay.ai/v1/bluejay-as-code`
 **Auth:** `X-API-Key` header
 **Content-Type:** application/json
 
@@ -21,10 +21,10 @@ You are a senior backend engineer integrating the Bluejay API. Think step-by-ste
 | Name | Type | Description |
 |------|------|-------------|
 | X-API-Key | string | API key required to authenticate requests. |
-| agents | array | Array containing exactly one agent object. |
-| simulations | array | Array containing exactly one simulation object. |
-| digital_humans | array | Array of digital human objects (can be empty). |
-| custom_metrics | array | Array of custom metric objects (can be empty). |
+| agents | array | Agent objects in the bundle (typically one for a simulation push). |
+| simulations | array | Simulation objects in the bundle (typically one for a simulation push). |
+| digital_humans | array | Digital human objects (can be empty). |
+| custom_metrics | array | Custom metric objects (can be empty). |
 
 Review the full schema at https://docs.getbluejay.ai/api-reference/endpoint/push-bluejay-as-code.
 
@@ -43,7 +43,7 @@ Review the full schema at https://docs.getbluejay.ai/api-reference/endpoint/push
 import requests
 
 def push_bluejay_as_code(payload: dict, api_key: str) -> dict:
-    url = "https://api.getbluejay.ai/v1/bluejay-as-code/simulation"
+    url = "https://api.getbluejay.ai/v1/bluejay-as-code"
     headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
     response = requests.post(url, headers=headers, json=payload)
     response.raise_for_status()

--- a/cookbook/bluejay-as-code-skill.mdx
+++ b/cookbook/bluejay-as-code-skill.mdx
@@ -77,27 +77,36 @@ You own the BaC IDs. This is intentional — it gives you full control over what
 
 ## Endpoints
 
-### Pull — GET /v1/bluejay-as-code/pull/{simulation_id}
+### Pull — GET /v1/bluejay-as-code/{root_type}/{root_id}
 
-Exports a simulation's full configuration as a BaC payload, with all bluejay_as_code_id values populated from Bluejay's database.
+Exports a Bluejay configuration bundle as a BaC payload, with all bluejay_as_code_id values populated from Bluejay's database. The bundle is rooted at any of four entity types — pick whichever entity is most natural to anchor on.
 
 Auth: X-API-Key header
 
-Path parameter:
+Path parameters:
 | Name | Type | Description |
 |------|------|-------------|
-| simulation_id | string | The Bluejay simulation ID to export. |
+| root_type | string | One of `simulation`, `agent`, `digital-human`, `custom-metric`. |
+| root_id | string | The Bluejay ID (or `bluejay_as_code_id` UUID) of the root entity. |
 
 Response: Full BaC payload with bluejay_as_code_id populated on every entity.
 
-Usage pattern: Pull once to bootstrap your config file. Commit the returned IDs — they are your source of truth going forward.
+Usage pattern: For most workflows, root on `simulation` — it pulls the simulation, its agent, every linked digital human, and every associated custom metric in one call. Pull once to bootstrap your config file, then commit the returned IDs — they are your source of truth going forward.
 
-### Push — POST /v1/bluejay-as-code/push
+### Push — POST /v1/bluejay-as-code
 
-Applies a BaC payload to Bluejay. Each entity is matched by bluejay_as_code_id and created, updated, or left untouched depending on whether it exists and whether its fields have changed.
+Applies a BaC payload to Bluejay. Each entity is matched by bluejay_as_code_id and created, updated, or left untouched depending on whether it exists and whether its fields have changed. The endpoint is the same regardless of which root_type was used to pull the bundle.
 
 Auth: X-API-Key header
 Content-Type: application/json
+
+Response shape:
+| Field | Type | Description |
+|-------|------|-------------|
+| valid | boolean | True iff the payload passed validation. Always check this before treating a push as successful. |
+| errors | EntityValidationError[] | Per-entity validation errors. Empty when `valid` is true. |
+| actions | string[] | Human-readable lines describing every create/update/link/detach Bluejay performed. |
+| simulation_id | integer \| null | Resolved Bluejay ID of the simulation in the bundle (when present). |
 
 Diffing behaviour:
 | Scenario | Result |

--- a/cookbook/bluejay-as-code.mdx
+++ b/cookbook/bluejay-as-code.mdx
@@ -20,8 +20,8 @@ sequenceDiagram
     Config File->>Bluejay: GET /bluejay-as-code/simulation/{simulation_id}
     Bluejay-->>Config File: JSON payload
     note over Config File: Edit fields, add/remove entities, commit
-    Config File->>Bluejay: POST /bluejay-as-code/simulation
-    Bluejay-->>Config File: { valid, actions[] }
+    Config File->>Bluejay: POST /bluejay-as-code
+    Bluejay-->>Config File: { valid, actions[], simulation_id }
 ```
 
 <Steps>
@@ -33,6 +33,10 @@ sequenceDiagram
       -H "X-API-Key: $BLUEJAY_API_KEY" \
       -o simulation.json
     ```
+
+    <Tip>
+      The pull endpoint also accepts three other root types if you'd rather anchor your bundle on something else: `GET /v1/bluejay-as-code/agent/{id}`, `/digital-human/{id}`, or `/custom-metric/{id}`. Each one walks the same graph and returns the same payload shape — pick whichever entity is most natural for your workflow. The rest of this guide uses the simulation root because it's the most common.
+    </Tip>
   </Step>
 
   <Step title="Inspect the file you pulled">
@@ -140,7 +144,7 @@ sequenceDiagram
     The response lists every action taken so you can confirm the reconciliation matches your diff.
 
     ```bash
-    curl https://api.getbluejay.ai/v1/bluejay-as-code/simulation \
+    curl https://api.getbluejay.ai/v1/bluejay-as-code \
       -H "X-API-Key: $BLUEJAY_API_KEY" \
       -H "Content-Type: application/json" \
       --data @simulation.json
@@ -149,14 +153,21 @@ sequenceDiagram
     ```json response
     {
       "valid": true,
+      "errors": [],
       "actions": [
-        { "type": "update", "entity": "agent", "bluejay_as_code_id": "f3d2a87c-1e4b-4b9a-9c2d-7f1e6b5a4c33" },
-        { "type": "create", "entity": "digital_human", "bluejay_as_code_id": "7e2c9a1b-3d4f-4a8e-b612-9c5f0d3a1e88" }
-      ]
+        "Updated agent 'Front Desk Scheduler'",
+        "Created digital human 'Eleanor Pham'",
+        "Linked 1 existing digital human(s) to simulation"
+      ],
+      "simulation_id": 1284
     }
     ```
   </Step>
 </Steps>
+
+<Note>
+  The push endpoint is a single `POST /v1/bluejay-as-code` regardless of which root type you pulled from — the payload itself describes everything Bluejay needs to reconcile. On success, the response includes the resolved `simulation_id` for the simulation in the bundle so you can deep-link straight into the UI.
+</Note>
 
 ## Endpoints
 
@@ -198,7 +209,7 @@ payload["digital_humans"].append({
 })
 
 # 4. Push
-result = requests.post(f"{BASE_URL}/bluejay-as-code/simulation", headers=headers, json=payload).json()
+result = requests.post(f"{BASE_URL}/bluejay-as-code", headers=headers, json=payload).json()
 
 assert result["valid"], result["errors"]
 for action in result["actions"]:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Bluejay as Code docs to reflect the new pull path with root types and the unified push path. Also documented the updated push response (string actions and resolved `simulation_id`).

- **Migration**
  - Use GET `/v1/bluejay-as-code/{root_type}/{root_id}` instead of `/simulation/{id}`. Supported: `simulation`, `agent`, `digital-human`, `custom-metric`.
  - Use POST `/v1/bluejay-as-code` instead of `/simulation`.
  - Handle push response changes: `actions` is an array of strings; `simulation_id` is included when present.

<sup>Written for commit 83ffac2affdb8d4742412a1f841cdede79be86a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

