### PR TITLE
11labs sim docs

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,14 @@ icon: clock
 rss: true
 ---
 
+<Update label="May 12th, 2026" tags={["New", "Simulations"]}>
+  ## ElevenLabs simulation integration
+
+  Bluejay can now drive simulations directly against ElevenLabs voice agents. Add **ElevenLabs** as a new connection type on your Bluejay agent, paste the ElevenLabs `agent_id`, and add your API key in our ElevenLabs Integration.
+
+  [ElevenLabs simulations](/simulation-integrations/eleven-labs) · [Queue simulation run](/api-reference/endpoint/queue-simulation-run)
+</Update>
+
 <Update label="April 23rd, 2026" tags={["New", "Digital Humans"]}>
   ## DTMF tool for Digital Humans
 

--- a/docs.json
+++ b/docs.json
@@ -220,6 +220,7 @@
                 "icon": "/logo/elevenlabs.svg",
                 "expanded": false,
                 "pages": [
+                  "simulation-integrations/eleven-labs",
                   "integrations/eleven-labs"
                 ]
               },

--- a/integrations/eleven-labs.mdx
+++ b/integrations/eleven-labs.mdx
@@ -7,23 +7,27 @@ icon: '/logo/elevenlabs.svg'
 
 This guide will walk you through how to connect your Eleven Labs agents to Bluejay's observability software. You can select Eleven Labs as your Voice AI Provider when in the Advanced settings tab of an existing agent.
 
+<Note>
+This is the **observability** integration (production calls into Bluejay via webhook). To run Bluejay simulations directly against an ElevenLabs Convai agent, see [ElevenLabs Simulations](/simulation-integrations/eleven-labs).
+</Note>
+
 <video controls className="w-full aspect-video rounded-xl" src="/videos/elevenlabs-walkthrough.mp4"></video>
 
 
 ### Quick Prerequisites
 
-- **Eleven Labs Labs Webhook Secret**
+- **Eleven Labs Webhook Secret**
 - **A Bluejay Account**
 - **Webhook URL:** `https://api.getbluejay.ai/v1/integrations/ElevenLabs`
 
 
 ### Setting Up the Integration
 
-### 1. Adding Your Eleven Labs Labs Webhook Secret
+### 1. Adding Your Eleven Labs Webhook Secret
 
 1. Navigate to the **Integrations** tab under your Organization's settings
-2. Click **Show Confgiuration** on the **Eleven Labs** input and copy the given URL
-3. Log into your Eleven Labs Labs account and go to **Settings**
+2. Click **Show Configuration** on the **Eleven Labs** input and copy the given URL
+3. Log into your Eleven Labs account and go to **Settings**
 4. Click on the **Select Webhook** button then click **Create Webhook**
 5. Enter a name and then **Paste the Webhook URL into the Callback URL field**
 6. Click **Create** and **Copy** the Secret Given 
@@ -36,9 +40,9 @@ This guide will walk you through how to connect your Eleven Labs agents to Bluej
   src="https://okihfrlvyycxyylukqey.supabase.co/storage/v1/object/public/bluejay-docs-files/eleven-labs-integration-add-key.mov"
 ></video>
 
-### 2. Configure Your Eleven Labs Labs Agent
+### 2. Configure Your Eleven Labs Agent
 
-1. Navigate to your **Eleven Labs Labs Agent Dashboard** and select the agent you would like to configure
+1. Navigate to your **Eleven Labs Agent Dashboard** and select the agent you would like to configure
 2. Click on the **Security** tab and then select the webhook you just created
 3. **Save your changes**
 

--- a/simulation-integrations/eleven-labs.mdx
+++ b/simulation-integrations/eleven-labs.mdx
@@ -1,0 +1,41 @@
+---
+title: "ElevenLabs Simulations"
+description: "Run Bluejay simulations against an ElevenLabs Convai agent"
+icon: "/logo/elevenlabs.svg"
+---
+
+## ElevenLabs
+
+If your voice agent is built in ElevenLabs, this is an easy way to simulate calls to it. We will manage the transport connection and place our digital human directly in communication with your agent.
+
+<Note>
+This is the **simulation** integration. For piping production ElevenLabs calls into Bluejay observability via webhook, see [ElevenLabs Observability](/integrations/eleven-labs).
+</Note>
+
+### Connection model
+
+Bluejay will connect to your ElevenLabs voice agent over WebSocket and establish a bidirectional audio/data stream, allowing our digital human to interact with your agent in real-time.
+
+## Quick Start
+
+1. **Create your ElevenLabs Voice Agent**: Create a voice agent in the [ElevenLabs dashboard](https://elevenlabs.io/app/conversational-ai), copying its `agent_id`.
+
+2. **Add ElevenLabs API Key**: Get your ElevenLabs API key and add it to Bluejay
+   - Retrieve your ElevenLabs API key from the ElevenLabs dashboard:
+     - Navigate to Developer
+     - Locate API Keys
+     - Create a new key and copy it
+   - Input your ElevenLabs API key into the Bluejay dashboard:
+     - Select your organization in the bottom left of the screen
+     - Select Integrations
+     - Locate ElevenLabs and add your API key
+
+3. **Create Bluejay Agent**:
+   - Select `ElevenLabs` as the Connection Type
+   - Paste the ElevenLabs `agent_id`
+
+4. **Create a Simulation**
+
+5. **Run the Simulation**
+
+6. **View Results**

--- a/test/simulations/tool-calls.mdx
+++ b/test/simulations/tool-calls.mdx
@@ -63,6 +63,14 @@ Bluejay joins the LiveKit room alongside your agent. When your agent invokes a t
 
 [LiveKit Integration Guide →](/simulation-integrations/livekit#tool-call-tracking)
 
+### ElevenLabs Integration
+
+**Best for**: agents hosted on ElevenLabs Conversational AI.
+
+Bluejay captures both client- and server-side tool calls automatically — no agent code or post-call API call required. Client tools are observed live on the conversation WebSocket; server-side webhook tools are pulled from ElevenLabs' conversation history at call end and merged into the same simulation result.
+
+[ElevenLabs Integration Guide →](/simulation-integrations/eleven-labs)
+
 ### Why SIP for Phone-Based Agents?
 
 If your agent runs through traditional phone systems (PSTN), basic telephony integration does **not** support tool call enrichment. To unlock tool call and metadata tracking for phone-based agents, you need SIP.
@@ -83,18 +91,19 @@ If your agent runs through traditional phone systems (PSTN), basic telephony int
 
 - **Phone-based agents** → follow the [SIP Integration Guide](/simulation-integrations/sip)
 - **Web-based agents** → follow the [WebSocket Integration Guide](/simulation-integrations/websockets)
+- **ElevenLabs Conversational AI agents** → no setup needed; tool calls are captured automatically by the [ElevenLabs Integration](/simulation-integrations/eleven-labs)
 
 ### 2. Track Tool Calls in Your Agent
 
 Implement tool call tracking wherever your agent invokes external tools, APIs, or business logic during a call:
 
 ```python
-def track_tool_call(tool_name, parameters, result, timestamp):
+def track_tool_call(name, parameters, output, start_offset_ms):
     return {
-        "tool_name": tool_name,
+        "name": name,
         "parameters": parameters,
-        "result": result,
-        "timestamp": timestamp
+        "output": output,
+        "start_offset_ms": start_offset_ms,
     }
 ```
 
@@ -126,10 +135,10 @@ After the call ends, use the `X-Simulation-Result-Id` to call the [`/v1/update-s
   ],
   "tool_calls": [
     {
-      "tool_name": "transfer_funds",
+      "name": "transfer_funds",
       "parameters": {"from": "12345", "to": "67890", "amount": 500},
-      "result": {"transaction_id": "txn_abc123", "status": "completed"},
-      "timestamp": "2024-01-15T10:32:00Z"
+      "output": {"transaction_id": "txn_abc123", "status": "completed"},
+      "start_offset_ms": 120000
     }
   ],
   "metadata": {
@@ -155,10 +164,10 @@ Track tool calls across agent handoffs and escalation workflows:
 {
   "tool_calls": [
     {
-      "tool_name": "route_to_specialist",
+      "name": "route_to_specialist",
       "parameters": {"customer_issue": "billing_inquiry", "current_agent": "tier1_support"},
-      "result": {"routed_to": "billing_specialist", "agent_id": "agent_billing_001"},
-      "timestamp": "2024-01-15T10:30:00Z"
+      "output": {"routed_to": "billing_specialist", "agent_id": "agent_billing_001"},
+      "start_offset_ms": 30000
     }
   ],
   "metadata": {
@@ -177,16 +186,16 @@ Monitor critical financial operations with audit trails:
 {
   "tool_calls": [
     {
-      "tool_name": "verify_account_ownership",
+      "name": "verify_account_ownership",
       "parameters": {"account_id": "12345", "verification_method": "voice_biometric"},
-      "result": {"verified": true, "confidence_score": 0.95},
-      "timestamp": "2024-01-15T10:30:00Z"
+      "output": {"verified": true, "confidence_score": 0.95},
+      "start_offset_ms": 30000
     },
     {
-      "tool_name": "initiate_wire_transfer",
+      "name": "initiate_wire_transfer",
       "parameters": {"from_account": "12345", "to_account": "67890", "amount": 1000.00},
-      "result": {"transaction_id": "wire_xyz789", "status": "pending_approval"},
-      "timestamp": "2024-01-15T10:31:00Z"
+      "output": {"transaction_id": "wire_xyz789", "status": "pending_approval"},
+      "start_offset_ms": 90000
     }
   ],
   "metadata": {
@@ -205,16 +214,16 @@ Track customer service interactions with order processing systems:
 {
   "tool_calls": [
     {
-      "tool_name": "lookup_order",
+      "name": "lookup_order",
       "parameters": {"order_id": "ORD-2024-001"},
-      "result": {"order_status": "shipped", "tracking_number": "1Z999AA1234567890"},
-      "timestamp": "2024-01-15T14:20:00Z"
+      "output": {"order_status": "shipped", "tracking_number": "1Z999AA1234567890"},
+      "start_offset_ms": 45000
     },
     {
-      "tool_name": "initiate_return",
+      "name": "initiate_return",
       "parameters": {"order_id": "ORD-2024-001", "reason": "size_issue"},
-      "result": {"return_id": "RET-2024-456", "prepaid_label": true},
-      "timestamp": "2024-01-15T14:21:00Z"
+      "output": {"return_id": "RET-2024-456", "prepaid_label": true},
+      "start_offset_ms": 105000
     }
   ],
   "metadata": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds docs for running Bluejay simulations against ElevenLabs Convai agents with automatic tool-call capture. Also updates the observability guide, changelog, navigation, and standardizes tool-call example fields.

- **New Features**
  - Added ElevenLabs simulation guide with connection model and quick start (`simulation-integrations/eleven-labs`).
  - Tool-calls guide now documents ElevenLabs integration and automatic client/server tool capture.
  - Changelog entry and docs sidebar updated to include ElevenLabs simulations.

- **Refactors**
  - Clarified `integrations/eleven-labs` as observability-only and fixed typos.
  - Standardized tool-call examples: `tool_name` → `name`, `result` → `output`, `timestamp` → `start_offset_ms`.

<sup>Written for commit 7c1d12680349c738ead99147e283a8d915404c6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

