### PR TITLE
docs: add traces for sims and observability with LiveKit SIP guide

### DIFF
--- a/core-concepts/traces/overview.mdx
+++ b/core-concepts/traces/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Traces"
-description: "Send realtime traces to Bluejay"
+title: "Overview"
+description: "Send OpenTelemetry traces to Bluejay for production observability and simulation analysis"
 icon: route
 ---
 
@@ -8,17 +8,14 @@ icon: route
 
 As part of your voice-agent stack, traces are used to monitor and observe the behavior of your application in real-time. They provide insights into the execution flow, latency, and performance of your system.
 
+Bluejay accepts traces for two purposes:
+
+- **Production observability** — link traces to call evaluations via the [`/v1/evaluate`](/api-reference/endpoint/evaluate) endpoint
+- **Simulation analysis** — link traces to simulation results via the [`/v1/update-simulation-result`](/api-reference/endpoint/update-simulation-result) endpoint
+
 ## Sending Traces to Bluejay
 
 Bluejay supports any traces that conform to the [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) standard, this includes OpenInference, Langfuse, OpenLLMetry, and more.
-
-To send traces to Bluejay:
-
-1. Instrument your application code to specify exporting your call traces to Bluejay.
-2. Link your traces to your call evaluations by including the `trace_id` in your requests to our [evaluate](/api-reference/endpoint/evaluate) endpoint.
-3. Visualize your traces along side your call evaluations in the Bluejay dashboard.
-
----
 
 ### Using OpenInference
 
@@ -57,3 +54,20 @@ OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic <BASE64_ENCODED_TRACE_KEY>"
 
 # collect traces via langfuse as normal
 ``` */}
+
+### Using LiveKit
+
+LiveKit requires additional setup — see the [LiveKit Traces guide](/simulation-integrations/livekit#linking-traces-to-simulation-results).
+
+---
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Traces for Observability" icon="eye" href="/monitor/observability/traces">
+    Link traces to production conversation evaluations.
+  </Card>
+  <Card title="Traces for Simulations" icon="flask-vial" href="/test/simulations/traces">
+    Link traces to simulation results.
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -203,6 +203,14 @@
                   "key-concepts/bluejay-as-code/overview",
                   "key-concepts/bluejay-as-code/skill"
                 ]
+              },
+              {
+                "group": "Traces",
+                "icon": "route",
+                "expanded": false,
+                "pages": [
+                  "core-concepts/traces/overview"
+                ]
               }
             ]
           },
@@ -218,6 +226,7 @@
                   "test/simulations/overview",
                   "test/simulations/types",
                   "test/simulations/tool-calls",
+                  "test/simulations/traces",
                   "core-concepts/simulation-runs",
                   "core-concepts/simulation-results",
                   "test/simulations/dashboards",
@@ -239,7 +248,7 @@
                   "monitor/observability/overview",
                   "monitor/observability/api-integration-tutorial",
                   "monitor/observability/tool-calls",
-                  "core-concepts/traces",
+                  "monitor/observability/traces",
                   "core-concepts/webhook",
                   "monitor/observability/dashboards",
                   "monitor/observability/alerts"

--- a/glossary.mdx
+++ b/glossary.mdx
@@ -348,7 +348,7 @@ See more: [Tool Calls & Metadata (Simulations)](/test/simulations/tool-calls) | 
   <div data-glossary-item data-term="Trace"><Accordion title="Trace">
 An execution record conforming to the OpenTelemetry standard that captures the internal flow of an agent during a conversation. Traces can be linked to evaluations via a trace_id for unified debugging.
 
-See more: [Traces](/core-concepts/traces) | [Evaluate API](/api-reference/endpoint/evaluate)
+See more: [Traces](/core-concepts/traces/overview) | [Evaluate API](/api-reference/endpoint/evaluate)
 </Accordion></div>
   <div data-glossary-item data-term="Transcript"><Accordion title="Transcript">
 The text record of conversation utterances with speaker roles (e.g. AGENT, CUSTOMER), used as the primary input for evaluation. Transcripts can be submitted directly or derived from a recording URL.
@@ -382,6 +382,6 @@ See more: [Scenario Builder Overview](/key-concepts/scenario-builder/overview) |
 - [Monitor Overview](/monitor/overview)
 - [Observability](/core-concepts/observability)
 - [Tool Calls & Metadata (Simulations)](/test/simulations/tool-calls) | [Tool Calls & Metadata (Observability)](/monitor/observability/tool-calls)
-- [Traces](/core-concepts/traces)
+- [Traces](/core-concepts/traces/overview)
 - [Integrations: Telephony](/simulation-integrations/telephony) | [SIP](/simulation-integrations/sip) | [LiveKit](/simulation-integrations/livekit) | [WebSockets](/simulation-integrations/websockets)
 - [API Reference](/api-reference/introduction)

--- a/monitor/observability/overview.mdx
+++ b/monitor/observability/overview.mdx
@@ -59,7 +59,7 @@ You can send conversations to Bluejay via the evaluate API, webhooks, or native 
   <Card title="Tool Calls" icon="wrench" href="/monitor/observability/tool-calls">
     Include tool call data and metadata in evaluations.
   </Card>
-  <Card title="Traces" icon="route" href="/core-concepts/traces">
+  <Card title="Traces" icon="route" href="/core-concepts/traces/overview">
     Send OpenTelemetry traces to Bluejay.
   </Card>
   <Card title="Webhooks" icon="bolt" href="/core-concepts/webhook">

--- a/monitor/observability/traces.mdx
+++ b/monitor/observability/traces.mdx
@@ -1,0 +1,30 @@
+---
+title: "Traces"
+description: "Link OpenTelemetry traces to production conversation evaluations"
+icon: route
+---
+
+Link OTLP traces to production conversation evaluations so the trace flamegraph appears alongside call evaluations in the Bluejay dashboard.
+
+```mermaid
+flowchart LR
+    App[Your Agent] -->|OTLP Spans| Collector[Bluejay Collector]
+    App --> End[Call Ends]
+    End --> Eval["POST /v1/evaluate<br/>with trace_id"]
+    Eval --> Dash[Dashboard: Evaluation + Trace]
+```
+
+## How It Works
+
+1. **Instrument your agent** to export OTLP traces to Bluejay — see [Sending Traces to Bluejay](/core-concepts/traces/overview).
+2. **Include the `trace_id`** in your request to the [`/v1/evaluate`](/api-reference/endpoint/evaluate) endpoint.
+3. **Visualize** traces alongside call evaluations in the Bluejay dashboard.
+
+<CardGroup cols={2}>
+  <Card title="Evaluate Endpoint" icon="code" href="/api-reference/endpoint/evaluate">
+    Full reference for the evaluate endpoint.
+  </Card>
+  <Card title="Sending Traces to Bluejay" icon="route" href="/core-concepts/traces/overview">
+    OTLP setup and instrumentation.
+  </Card>
+</CardGroup>

--- a/simulation-integrations/livekit.mdx
+++ b/simulation-integrations/livekit.mdx
@@ -56,8 +56,79 @@ The only required field is `name`. Everything else is optional:
 | `name` | string | **Required.** The tool that was invoked |
 | `parameters` | object | Input parameters passed to the tool |
 | `output` | any | Return value of the tool |
-| `invocation_id` | string | Unique ID to prevent duplicate ingestion on retries |
 | `start_offset_ms` | integer | Milliseconds from call start (Bluejay calculates if omitted) |
-| `client_ts` | string | ISO 8601 timestamp, used to calculate offset if `start_offset_ms` is not set |
 
 Bluejay buffers packets during the call and persists them automatically when the simulation ends.
+
+## Sending Traces to Bluejay
+
+Export OpenTelemetry traces from your LiveKit agent to Bluejay so traces are used and displayed for simulation evaluations.
+
+```python
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from livekit.agents.telemetry import set_tracer_provider
+import opentelemetry.trace as otel_trace
+
+resource = Resource.create({SERVICE_NAME: "my-agent"})
+tracer_provider = trace_sdk.TracerProvider(resource=resource)
+tracer_provider.add_span_processor(
+    SimpleSpanProcessor(
+        OTLPSpanExporter(
+            "https://otlp.getbluejay.ai/v1/traces",
+            headers={"X-API-KEY": BLUEJAY_API_KEY},
+        )
+    )
+)
+
+# Set both LiveKit internal + global OpenTelemetry
+set_tracer_provider(tracer_provider)
+otel_trace.set_tracer_provider(tracer_provider)
+```
+
+After `session.start()`, LiveKit's agent session span is active in the OpenTelemetry context. Capture the trace ID from it:
+
+```python
+import opentelemetry.trace as otel_trace
+
+await session.start(agent=MyAgent(), room=ctx.room)
+
+current_span = otel_trace.get_current_span()
+span_ctx = current_span.get_span_context()
+if span_ctx.is_valid:
+    trace_ids = [format(span_ctx.trace_id, "032x")]
+```
+
+## Linking Information to Simulation Results
+
+POST trace IDs and tool calls at shutdown via `ctx.add_shutdown_callback()`:
+
+```python
+async def on_shutdown():
+    span.end()
+    tracer_provider.force_flush()
+
+    if simulation_result_id and (trace_ids or tool_calls):
+        async with httpx.AsyncClient(timeout=10) as client:
+            await client.post(
+                "https://api.getbluejay.ai/v1/update-simulation-result",
+                json={
+                    "simulation_result_id": simulation_result_id,
+                    "trace_ids": trace_ids,
+                    "tool_calls": tool_calls
+                },
+                headers={"X-API-Key": BLUEJAY_API_KEY},
+            )
+
+    tracer_provider.shutdown()
+
+ctx.add_shutdown_callback(on_shutdown)
+```
+
+<Tip>
+  Ordering matters: `span.end()` → `force_flush()` → POST → `tracer_provider.shutdown()`. If you POST before ending the span, the trace may not be in Bluejay yet.
+</Tip>
+
+For the full traces concept, see the [Traces](/core-concepts/traces/overview) documentation.

--- a/simulation-integrations/sip.mdx
+++ b/simulation-integrations/sip.mdx
@@ -70,9 +70,85 @@ def handle_sip_invite(invite_message):
 
 Using this header, you can now enrich your simulation evaluations by calling the [`/v1/update-simulation-result`](/api-reference/endpoint/update-simulation-result) endpoint.
 
-For more information, see the [Tool Calls & Metadata](/test/simulations/tool-calls#3-send-data-to-bluejay) documentation.
+For more information, see the [Tool Calls & Metadata](/test/simulations/tool-calls#3-send-data-to-bluejay) documentation. You can also link [OpenTelemetry traces](/core-concepts/traces/overview#linking-traces-to-simulation-results) to simulation results using the same endpoint.
 
 ## Integrations Guides
+
+<Accordion title="Connecting With LiveKit via SIP">
+
+<Note>
+  For most LiveKit users, the [direct LiveKit integration](/simulation-integrations/livekit) is the recommended approach — Bluejay manages room creation and joins the room directly alongside your agent. SIP connectivity for LiveKit is a more custom option for teams that need SIP-level control or are running LiveKit with an existing SIP infrastructure.
+</Note>
+
+To connect Bluejay to a LiveKit agent via SIP, you need to configure your LiveKit SIP inbound trunk to forward custom headers so your agent can receive the `X-Simulation-Result-Id`.
+
+### 1. Configure Header Forwarding on Your SIP Trunk
+
+LiveKit drops custom SIP headers by default. You must add `headers_to_attributes` to your SIP inbound trunk configuration:
+
+```bash
+# Find your trunk ID
+lk sip inbound list
+
+# Add header forwarding (re-include your allowed_addresses or numbers)
+echo '{
+  "headers_to_attributes": {
+    "X-Simulation-Result-Id": "X-Simulation-Result-Id"
+  },
+  "allowed_addresses": ["0.0.0.0/0"]
+}' | lk sip inbound update --id <TRUNK_ID> -
+```
+
+After this, `X-Simulation-Result-Id` will appear in `participant.attributes` alongside the standard `sip.*` keys.
+
+### 2. Extract the Simulation Result ID
+
+Once header forwarding is configured, `X-Simulation-Result-Id` appears directly in the SIP participant's attributes:
+
+```python
+def get_simulation_result_id(ctx):
+    for p in ctx.room.remote_participants.values():
+        sim_id = p.attributes.get("X-Simulation-Result-Id")
+        if sim_id:
+            return sim_id
+    return None
+```
+
+### 3. Send Data to Bluejay
+
+After the call ends, use the extracted `simulation_result_id` to call the [`/v1/update-simulation-result`](/api-reference/endpoint/update-simulation-result) endpoint with tool calls, metadata, and trace IDs.
+
+```python
+import requests
+
+url = "https://api.getbluejay.ai/v1/update-simulation-result"
+headers = {
+    "X-API-Key": "<your-api-key>"
+}
+
+def update_simulation_result(simulation_result_id, tool_calls, metadata, trace_ids=None):
+    data = {
+        "simulation_result_id": simulation_result_id,
+        "tool_calls": tool_calls,
+        "metadata": metadata,
+    }
+    if trace_ids:
+        data["trace_ids"] = trace_ids
+    response = requests.post(url, headers=headers, json=data)
+    return response.json()
+```
+
+### 4. Configure Agent Connection
+
+In the Bluejay dashboard, set your agent connection type to **SIP** with your LiveKit SIP URI:
+
+```
+sip:<subdomain>.sip.livekit.cloud
+```
+
+The subdomain is your LiveKit Cloud project's SIP hostname.
+
+</Accordion>
 
 <Accordion title="Connecting With VAPI">
 1. Start by create a SIP URI in VAPI, go to phone numbers and click on the create a new phone number. Click on the Free VAPI SIP option and specify the SIP identifier you want to use in your URI.

--- a/test/simulations/tool-calls.mdx
+++ b/test/simulations/tool-calls.mdx
@@ -6,6 +6,10 @@ icon: wrench
 
 Bluejay can ingest the tool calls and metadata your voice agent produces during simulations, giving you evaluation data that goes far beyond transcript analysis. By capturing every API call, database query, and business action your agent takes, you can measure whether it performed the right operations — not just whether it said the right things.
 
+<Note>
+  The [`/v1/update-simulation-result`](/api-reference/endpoint/update-simulation-result) endpoint also accepts `trace_ids` for linking OpenTelemetry traces to simulation results. See [Traces](/core-concepts/traces/overview#linking-traces-to-simulation-results) for details.
+</Note>
+
 ## How It Works
 
 During a simulation, Bluejay provides a unique `X-Simulation-Result-Id` for each conversation. Your agent must extract this ID, track its tool calls and metadata during the call, and then send that data back to Bluejay post-call via the [`/v1/update-simulation-result`](/api-reference/endpoint/update-simulation-result) endpoint.
@@ -245,7 +249,10 @@ Track customer service interactions with order processing systems:
   <Card title="WebSocket Integration" icon="tower-broadcast" href="/simulation-integrations/websockets">
     Connect web-based agents via CHIRP protocol.
   </Card>
+  <Card title="Traces" icon="route" href="/core-concepts/traces/overview#linking-traces-to-simulation-results">
+    Link OpenTelemetry traces to simulation results.
+  </Card>
   <Card title="Tool Calls" icon="eye" href="/monitor/observability/tool-calls">
-    Pass tool calls for production call evaluations instead.
+    Pass tool calls for production conversation evaluations instead.
   </Card>
 </CardGroup>

--- a/test/simulations/traces.mdx
+++ b/test/simulations/traces.mdx
@@ -1,0 +1,61 @@
+---
+title: "Traces"
+description: "Link OpenTelemetry traces to simulation results"
+icon: route
+---
+
+Link OTLP traces to simulation results so the trace flamegraph appears alongside the simulation evaluation in the Bluejay dashboard.
+
+```mermaid
+flowchart LR
+    Sim[Bluejay Starts Sim] --> Agent[Your Agent]
+    Agent -->|OTLP Spans| Collector[Bluejay Collector]
+    Agent --> End[Call Ends]
+    End --> Post["POST /v1/update-simulation-result<br/>with simulation_result_id + trace_ids"]
+    Post --> Dash[Dashboard: Sim Result + Trace]
+```
+
+## How It Works
+
+1. **Instrument your agent** to export OTLP traces to Bluejay — see [Sending Traces to Bluejay](/core-concepts/traces/overview).
+2. **Collect trace IDs** generated during the simulation call.
+3. **Extract the `simulation_result_id`** — Bluejay injects `X-Simulation-Result-Id` into every simulation call via SIP headers, WebSocket connect messages, or LiveKit participant attributes.
+4. **POST to [`/v1/update-simulation-result`](/api-reference/endpoint/update-simulation-result)** with both `simulation_result_id` and `trace_ids` after the call ends.
+
+```python
+import httpx
+
+async def link_traces_to_simulation(simulation_result_id, trace_ids, api_key):
+    async with httpx.AsyncClient(timeout=10) as client:
+        await client.post(
+            "https://api.getbluejay.ai/v1/update-simulation-result",
+            json={
+                "simulation_result_id": simulation_result_id,
+                "trace_ids": trace_ids,
+            },
+            headers={"X-API-Key": api_key},
+        )
+```
+
+<Tip>
+  Call `tracer_provider.force_flush()` before POSTing trace IDs. If you POST before the spans have been exported, the traces may not be available in Bluejay yet.
+</Tip>
+
+<Note>
+  The [`/v1/update-simulation-result`](/api-reference/endpoint/update-simulation-result) endpoint also accepts `tool_calls`, `events`, and `metadata` alongside `trace_ids`. See [Simulation Tool Calls](/test/simulations/tool-calls) for details.
+</Note>
+
+<CardGroup cols={2}>
+  <Card title="Update Simulation Result" icon="flask-vial" href="/api-reference/endpoint/update-simulation-result">
+    Full endpoint reference.
+  </Card>
+  <Card title="Simulation Tool Calls" icon="wrench" href="/test/simulations/tool-calls">
+    Enrich simulation results with tool call data.
+  </Card>
+  <Card title="LiveKit Traces" icon="/logo/livekit.svg" href="/simulation-integrations/livekit#sending-traces-to-bluejay">
+    LiveKit-specific trace linking guide.
+  </Card>
+  <Card title="Sending Traces to Bluejay" icon="route" href="/core-concepts/traces/overview">
+    OTLP setup and instrumentation.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
- Move core-concepts/traces.mdx to traces/overview.mdx with folder structure
- Add monitor/observability/traces.mdx for linking traces to production evals
- Add test/simulations/traces.mdx for linking traces to simulation results
- Add LiveKit SIP accordion to sip.mdx with trunk config and header forwarding
- Add traces section to livekit.mdx with OTLP setup and shutdown callback
- Update tool-calls.mdx to reference trace_ids as sibling enrichment type
- Update docs.json nav: Traces group in Key Concepts, traces in Observability and Simulations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end docs for linking OpenTelemetry traces to both production evaluations and simulation results, plus a LiveKit SIP guide. Clarifies OTLP setup, how to send `trace_id`/`trace_ids`, and improves trace visibility in the dashboard.

- **New Features**
  - Reorganized Traces docs: moved to `core-concepts/traces/overview` with dedicated pages for Observability (`/v1/evaluate` with `trace_id`) and Simulations (`/v1/update-simulation-result` with `trace_ids`).
  - LiveKit updates: added OTLP exporter setup, trace ID capture, and shutdown callback ordering; new SIP guide for header forwarding of `X-Simulation-Result-Id` and posting tool calls/trace IDs.
  - Tool Calls docs now reference `trace_ids` as a sibling enrichment type.
  - Navigation and glossary updated to reflect the new Traces structure and links.

<sup>Written for commit c03ac368bf3061304c5894b133727071dade3dd8. Summary will update on new commits. <a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/207?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

