### PR TITLE
docs: traces for sims, observability, and LiveKit SIP guide

### DIFF
--- a/core-concepts/traces/overview.mdx
+++ b/core-concepts/traces/overview.mdx
@@ -17,6 +17,15 @@ Bluejay accepts traces for two purposes:
 
 Bluejay supports any traces that conform to the [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) standard, this includes OpenInference, Langfuse, OpenLLMetry, and more.
 
+<iframe
+  src="https://www.youtube.com/embed/wNhFpwT3dTQ"
+  width="100%"
+  height="450"
+  frameBorder="0"
+  allowFullScreen
+  style={{ borderRadius: '0.5rem' }}
+></iframe>
+
 ### Using OpenInference
 
 Send traces to Bluejay using OpenInference by configuring your OpenTelemetry SDK with the appropriate exporter. Below is an example of how to set up the OpenTelemetry SDK to send traces to Bluejay:


### PR DESCRIPTION
## What's changed

- **Traces overview** moved to `core-concepts/traces/overview` with folder structure and dropdown nav group under Key Concepts
- **New page**: `monitor/observability/traces.mdx` — linking traces to production conversation evaluations via `/v1/evaluate`
- **New page**: `test/simulations/traces.mdx` — linking traces to simulation results via `/v1/update-simulation-result`
- **LiveKit**: added SIP accordion to `simulation-integrations/sip.mdx` with trunk config and `X-Simulation-Result-Id` extraction
- **LiveKit**: added traces section to `simulation-integrations/livekit.mdx` with OTLP setup, trace ID capture, and shutdown callback pattern
- **Tool calls**: updated to reference `trace_ids` as sibling enrichment type
- **Video**: added traces integration walkthrough to overview page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded and reorganized trace docs to connect traces with production evaluations, simulations, and LiveKit; added a quick setup video. This improves discoverability and shows how to pass trace IDs through `/v1/evaluate`, `/v1/update-simulation-result`, and LiveKit SIP.

- **Docs**
  - Moved traces overview to `core-concepts/traces/overview` under Key Concepts; embedded a walkthrough video.
  - New pages: observability traces (via `/v1/evaluate`) and simulations traces (via `/v1/update-simulation-result`).
  - LiveKit: added SIP guidance (trunk config, `X-Simulation-Result-Id`) and traces setup (OTLP, trace ID capture, shutdown callback).
  - Updated tool calls to reference `trace_ids` as a sibling enrichment type.

<sup>Written for commit 40a1be12b57b0290fab6c8470cfa3e4185552ccf. Summary will update on new commits. <a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/208?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

