### PR TITLE
docs: traces video, OpenTelemetry SDK section rename

### DIFF
--- a/core-concepts/traces/overview.mdx
+++ b/core-concepts/traces/overview.mdx
@@ -4,6 +4,15 @@ description: "Send OpenTelemetry traces to Bluejay for production observability 
 icon: route
 ---
 
+<iframe
+  src="https://www.youtube.com/embed/wNhFpwT3dTQ"
+  width="100%"
+  height="450"
+  frameBorder="0"
+  allowFullScreen
+  style={{ borderRadius: '0.5rem' }}
+></iframe>
+
 ## What are Traces?
 
 As part of your voice-agent stack, traces are used to monitor and observe the behavior of your application in real-time. They provide insights into the execution flow, latency, and performance of your system.
@@ -17,20 +26,11 @@ Bluejay accepts traces for two purposes:
 
 Bluejay supports any traces that conform to the [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) standard, this includes OpenInference, Langfuse, OpenLLMetry, and more.
 
-<iframe
-  src="https://www.youtube.com/embed/wNhFpwT3dTQ"
-  width="100%"
-  height="450"
-  frameBorder="0"
-  allowFullScreen
-  style={{ borderRadius: '0.5rem' }}
-></iframe>
+### Using the OpenTelemetry SDK
 
-### Using OpenInference
+Configure the OpenTelemetry SDK to export traces to Bluejay:
 
-Send traces to Bluejay using OpenInference by configuring your OpenTelemetry SDK with the appropriate exporter. Below is an example of how to set up the OpenTelemetry SDK to send traces to Bluejay:
-
-```python highlight={14-15}
+```python
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -44,7 +44,6 @@ headers = {
     "X-API-KEY": "[BLUEJAY PROVISIONED API KEY]"
 }
 
-# utilize this tracer_provider with any OpenTelemetry/OpenInference instrumentation
 tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter(endpoint, headers=headers)))
 ```
 


### PR DESCRIPTION
- Move integration video to top of traces overview
- Rename 'Using OpenInference' section to 'Using the OpenTelemetry SDK'

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the integration video to the top of the Traces overview for quicker onboarding, and renamed “Using OpenInference” to “Using the OpenTelemetry SDK” to reflect the recommended setup.
Also simplified the example and wording to focus on configuring the OpenTelemetry SDK to export traces to Bluejay.

<sup>Written for commit 6676f2c32d0dbbbecaca8a7817279d0b5fc1a46e. Summary will update on new commits. <a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/209?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

