### PR TITLE
fix(bac): repoint skill.txt download to GitHub raw

### DIFF
--- a/key-concepts/bluejay-as-code/skill.mdx
+++ b/key-concepts/bluejay-as-code/skill.mdx
@@ -22,7 +22,7 @@ This is a Claude Code skill — a plain-text system prompt you drop into your pr
 
 Claude will follow the integration constraints and checklist defined in the skill when generating or reviewing Bluejay as Code integration code.
 
-<Card title="Download skill" icon="download" href="https://docs.getbluejay.ai/key-concepts/bluejay-as-code/skill.txt">
+<Card title="Download skill" icon="download" href="https://raw.githubusercontent.com/bluejay-ai-dev/docs/main/key-concepts/bluejay-as-code/skill.txt">
   `bluejay-as-code-skill.txt`
 </Card>
 


### PR DESCRIPTION
## Summary
- The Download card on `/key-concepts/bluejay-as-code/skill` was 404ing on prod because Mintlify only serves `.txt` static assets on Enterprise plans.
- Repoint the card href to `raw.githubusercontent.com/bluejay-ai-dev/docs/main/...` so it bypasses the Mintlify CDN allowlist. The docs repo is public, no auth needed.

## Test plan
- [x] Verified locally with `mint dev` — page renders, Download button now points at GitHub raw URL.
- [ ] After merge to `dev`, hit the deployed preview's Download card and confirm `skill.txt` downloads (instead of 404).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 404 on the “Download skill” card by pointing `skill.txt` to the GitHub raw URL instead of the Mintlify-hosted path. Users can now download the skill file reliably in production.

<sup>Written for commit e922ef0cdb966e04f99c19dd0511ca6657c89ed4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/216?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

