### PR TITLE
docs(journey): embed walkthrough video at top of Customer Journeys

### DIFF
--- a/test/simulations/customer-journeys.mdx
+++ b/test/simulations/customer-journeys.mdx
@@ -8,6 +8,15 @@ Real customers rarely call once. They book, then call back to confirm, then call
 
 **Customer Journeys** is a Bluejay simulation type that runs a fixed sequence of calls through a single Digital Human. Identity (name, phone, persona, traits) stays locked across every call in the sequence. The next call kicks off as the previous one completes, so you can stress-test how your agent handles repeat-customer state, hand-offs between flows, and follow-up logic.
 
+<iframe
+  src="https://www.youtube.com/embed/MywLdzH9J3g"
+  width="100%"
+  height="450"
+  frameBorder="0"
+  allowFullScreen
+  style={{ borderRadius: '0.5rem' }}
+></iframe>
+
 {/* SCREENSHOT — Create Simulation modal with the Customer Journeys card highlighted in the type grid. */}
 ![Customer Journeys card on the Create Simulation modal](/images/journey-card.png)
 


### PR DESCRIPTION
## Summary
Embeds the Customer Journeys walkthrough video at the top of `/test/simulations/customer-journeys` (just below the intro paragraphs, above the type-grid screenshot).

Uses the same iframe pattern as `/core-concepts/traces/overview` and `/key-concepts/bluejay-as-code/overview` — 100% width, 450px tall, `0.5rem` border radius.

Video: https://www.youtube.com/watch?v=MywLdzH9J3g

## Test plan
- [ ] `/test/simulations/customer-journeys` renders the YouTube embed above the journey-card screenshot
- [ ] Video plays inline, fullscreen toggle works
- [ ] Page still builds clean in `mintlify dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embed the Customer Journeys walkthrough video at the top of /test/simulations/customer-journeys to give users a quick overview before the screenshot. Uses the same YouTube iframe style as other docs (100% width, 450px height, 0.5rem border radius).

<sup>Written for commit 4be35dab4359c847c9ea4ba3d47f8277da72d0a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/218?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

