### PR TITLE
docs(vapi): embed walkthrough video at top of Vapi Simulations

### DIFF
--- a/simulation-integrations/vapi.mdx
+++ b/simulation-integrations/vapi.mdx
@@ -7,6 +7,15 @@ icon: '/logo/vapi.svg'
 
 This guide walks you through running Bluejay simulations directly against your Vapi assistants. Once configured, every simulation Bluejay runs against a Vapi-bound agent will route inbound through the Vapi bridge automatically, and every tool call the assistant makes during the conversation will land in Bluejay's Tool Adherence tab.
 
+<iframe
+  src="https://www.youtube.com/embed/jw_gipBfr3Y"
+  width="100%"
+  height="450"
+  frameBorder="0"
+  allowFullScreen
+  style={{ borderRadius: '0.5rem' }}
+></iframe>
+
 ### Quick Prerequisites
 
 - **Vapi public + private API keys**


### PR DESCRIPTION
## Summary
Embeds the Vapi Simulations walkthrough at the top of `/simulation-integrations/vapi`, just below the intro paragraph.

Same iframe pattern as the Customer Journeys, Traces, and Bluejay-as-Code overview pages — 100% wide, 450px tall, `0.5rem` border radius.

Video: https://youtu.be/jw_gipBfr3Y

## Test plan
- [ ] `/simulation-integrations/vapi` renders the YouTube embed below the intro paragraph
- [ ] Video plays inline, fullscreen toggle works
- [ ] Page still builds clean in `mintlify dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embeds the Vapi Simulations walkthrough video at the top of /simulation-integrations/vapi, just below the intro.
Uses the same iframe pattern as other overview docs (100% width, 450px height, 0.5rem radius) with inline playback and fullscreen support.

<sup>Written for commit 7ae526d61fd1dba2ae307b2129de366d7843d4c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/219?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

