### PR TITLE
docs(api): document the Alerts endpoints

### DIFF
--- a/api-reference/endpoint/create-alert.mdx
+++ b/api-reference/endpoint/create-alert.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Create Alert'
+description: 'Create an observability or simulation alert for your organization.'
+openapi: 'POST /v1/create-alert'
+---

--- a/api-reference/endpoint/delete-alert.mdx
+++ b/api-reference/endpoint/delete-alert.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Delete Alert'
+description: 'Delete an alert and its agent associations.'
+openapi: 'DELETE /v1/alert/{alert_id}'
+---

--- a/api-reference/endpoint/get-alert-results.mdx
+++ b/api-reference/endpoint/get-alert-results.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Get Alert Results'
+description: 'Retrieve the fired results for an alert, each resolved to the simulation run or observability call that caused it.'
+openapi: 'GET /v1/alerts/{alert_id}/results'
+---

--- a/api-reference/endpoint/get-alerts.mdx
+++ b/api-reference/endpoint/get-alerts.mdx
@@ -1,0 +1,5 @@
+---
+title: 'List Alerts'
+description: 'List all alerts for your organization, optionally filtered by source scope (observability or simulation).'
+openapi: 'GET /v1/alerts'
+---

--- a/api-reference/endpoint/update-alert.mdx
+++ b/api-reference/endpoint/update-alert.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Update Alert'
+description: 'Update an existing alert. Unset fields are preserved; nullable fields can be cleared explicitly.'
+openapi: 'PUT /v1/update-alert/{alert_id}'
+---

--- a/docs.json
+++ b/docs.json
@@ -484,6 +484,18 @@
                 ]
               },
               {
+                "group": "Alerts",
+                "icon": "bell",
+                "expanded": false,
+                "pages": [
+                  "api-reference/endpoint/create-alert",
+                  "api-reference/endpoint/update-alert",
+                  "api-reference/endpoint/get-alerts",
+                  "api-reference/endpoint/get-alert-results",
+                  "api-reference/endpoint/delete-alert"
+                ]
+              },
+              {
                 "group": "Custom Metrics",
                 "icon": "gauge-high",
                 "expanded": false,


### PR DESCRIPTION
## What

Adds an **Alerts** group to the API Reference (was missing entirely — these endpoints worked via API but weren't published):

- `create-alert` → `POST /v1/create-alert`
- `update-alert` → `PUT /v1/update-alert/{alert_id}`
- `get-alerts` (list) → `GET /v1/alerts`
- `get-alert-results` → `GET /v1/alerts/{alert_id}/results` *(new endpoint, middleware PR #758)*
- `delete-alert` → `DELETE /v1/alert/{alert_id}`

Each page is a frontmatter `.mdx` rendering from the live OpenAPI spec (`api.openapi` in `docs.json`), matching the existing endpoint-page pattern, plus a new nav group in `docs.json`.

## Notes
- Pages render from the **live** prod spec, so `get-alert-results` populates once middleware #758 deploys; the four CRUD pages resolve as soon as those routes are in the prod spec.
- AI-prompt boxes are left to the repo's `scripts/generate_ai_prompts.py` (frontmatter-only, same as the existing `create-digital-humans.mdx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing Alerts endpoints to the API Reference and adds an "Alerts" nav group. Pages render from the live OpenAPI spec to keep docs in sync.

- **New Features**
  - Added docs for `POST /v1/create-alert`, `PUT /v1/update-alert/{alert_id}`, `GET /v1/alerts`, `GET /v1/alerts/{alert_id}/results`, and `DELETE /v1/alert/{alert_id}`.
  - Added the "Alerts" group to `docs.json` navigation.
  - Pages source their content from the live spec; `GET /v1/alerts/{alert_id}/results` populates once its middleware deploys.

<sup>Written for commit d56f5a9b5334b2175c544d47f7d57fe86ed238f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

