### PR TITLE
Dev

### DIFF
--- a/api-reference/endpoint/create-alert.mdx
+++ b/api-reference/endpoint/create-alert.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Create Alert'
+description: 'Create an observability or simulation alert for your organization.'
+openapi: 'POST /v1/create-alert'
+---

--- a/api-reference/endpoint/delete-alert.mdx
+++ b/api-reference/endpoint/delete-alert.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Delete Alert'
+description: 'Delete an alert and its agent associations.'
+openapi: 'DELETE /v1/alert/{alert_id}'
+---

--- a/api-reference/endpoint/get-alert-results.mdx
+++ b/api-reference/endpoint/get-alert-results.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Get Alert Results'
+description: 'Retrieve the fired results for an alert, each resolved to the simulation run or observability call that caused it.'
+openapi: 'GET /v1/alerts/{alert_id}/results'
+---

--- a/api-reference/endpoint/get-alerts.mdx
+++ b/api-reference/endpoint/get-alerts.mdx
@@ -1,0 +1,5 @@
+---
+title: 'List Alerts'
+description: 'List all alerts for your organization, optionally filtered by source scope (observability or simulation).'
+openapi: 'GET /v1/alerts'
+---

--- a/api-reference/endpoint/update-alert.mdx
+++ b/api-reference/endpoint/update-alert.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Update Alert'
+description: 'Update an existing alert. Unset fields are preserved; nullable fields can be cleared explicitly.'
+openapi: 'PUT /v1/update-alert/{alert_id}'
+---

--- a/docs.json
+++ b/docs.json
@@ -484,6 +484,18 @@
                 ]
               },
               {
+                "group": "Alerts",
+                "icon": "bell",
+                "expanded": false,
+                "pages": [
+                  "api-reference/endpoint/create-alert",
+                  "api-reference/endpoint/update-alert",
+                  "api-reference/endpoint/get-alerts",
+                  "api-reference/endpoint/get-alert-results",
+                  "api-reference/endpoint/delete-alert"
+                ]
+              },
+              {
                 "group": "Custom Metrics",
                 "icon": "gauge-high",
                 "expanded": false,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an “Alerts” section to the API Reference so users can create, update, list, view results for, and delete alerts via documented endpoints powered by the live OpenAPI spec.

- **New Features**
  - Docs for `POST /v1/create-alert`, `PUT /v1/update-alert/{alert_id}`, `GET /v1/alerts`, `GET /v1/alerts/{alert_id}/results`, `DELETE /v1/alert/{alert_id}` (rendered from OpenAPI).
  - New “Alerts” group in the API Reference nav (icon: bell).

<sup>Written for commit 6dd211ce9371255d78bd604867f442327120f123. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

