### PR TITLE
Add Customer Journeys section to Bluejay as Code docs

### DIFF
--- a/key-concepts/bluejay-as-code/overview.mdx
+++ b/key-concepts/bluejay-as-code/overview.mdx
@@ -224,3 +224,44 @@ assert result["valid"], result["errors"]
 for action in result["actions"]:
     print(action)
 ```
+
+## Customer Journeys
+
+A **Customer Journey** is a single digital human that places a *sequence* of calls — the same caller, returning across steps, with context from earlier calls carried into later ones. Use it to test multi-call flows like *book → confirm → cancel*, where each call depends on the state left by the one before it.
+
+In Bluejay as Code a journey is just a digital human with two extra fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `tag` | string | `"Customer Journey"`. Marks the digital human as a journey. Optional on push — Bluejay applies it automatically whenever `journey_steps` is present. |
+| `journey_steps` | array | The ordered calls. Each step is `{ "step", "intent", "success_criteria" }`. |
+
+Each step:
+
+- **`step`** (int) — the call's position in the sequence. Step numbers must be **unique and contiguous starting at `0`** (`0, 1, 2, …`). Calls run strictly in this order, each gated until the previous one completes.
+- **`intent`** (string, **required**) — what the simulated caller is trying to do on *this* call. A step with no intent is rejected.
+- **`success_criteria`** (string, optional) — how that individual call is graded.
+
+```json simulation.json
+{
+  "bluejay_as_code_id": "d4f8a2c1-6b3e-4a09-8f27-1c5e9b0d3a76",
+  "human_name": "Returning Caller",
+  "tag": "Customer Journey",
+  "simulations": ["b1a04e88-7c2f-4d23-9a5e-2f8c6d1b7a09"],
+  "journey_steps": [
+    { "step": 0, "intent": "Book a Tuesday morning physical with Dr. Patel", "success_criteria": "Appointment booked and confirmation number read back" },
+    { "step": 1, "intent": "Call back to confirm the appointment", "success_criteria": "Agent confirms the existing booking" },
+    { "step": 2, "intent": "Cancel the appointment", "success_criteria": "Appointment cancelled and cancellation acknowledged" }
+  ]
+}
+```
+
+On the next run this one digital human expands into three chained calls — step 0 → 1 → 2 — each carrying the prior call's context forward so the agent sees a returning customer.
+
+<Note>
+  **`journey_steps` defines the journey.** Any digital human with a non-empty `journey_steps` array is treated as a journey and round-trips its steps on pull/push; Bluejay auto-applies the `"Customer Journey"` tag so you never have to set it by hand. Conversely, a digital human tagged `"Customer Journey"` with no steps is rejected — a journey needs at least one call.
+</Note>
+
+<Tip>
+  Push validates journeys before writing anything. Non-contiguous `step` values (e.g. `[0, 2, 5]`), duplicates, or a step with an empty `intent` come back as `valid: false` with a per-entity error and **no** changes applied. Fix the payload and push again.
+</Tip>

--- a/key-concepts/bluejay-as-code/overview.mdx
+++ b/key-concepts/bluejay-as-code/overview.mdx
@@ -238,7 +238,7 @@ In Bluejay as Code a journey is just a digital human with two extra fields:
 
 Each step:
 
-- **`step`** (int) — the call's position in the sequence. Step numbers must be **unique and contiguous starting at `0`** (`0, 1, 2, …`). Calls run strictly in this order, each gated until the previous one completes.
+- **`step`** (int) — the call's position in the sequence. Step numbers must be **unique and contiguous starting at `1`** (`1, 2, 3, …`). Calls run strictly in this order, each gated until the previous one completes.
 - **`intent`** (string, **required**) — what the simulated caller is trying to do on *this* call. A step with no intent is rejected.
 - **`success_criteria`** (string, optional) — how that individual call is graded.
 
@@ -249,19 +249,19 @@ Each step:
   "tag": "Customer Journey",
   "simulations": ["b1a04e88-7c2f-4d23-9a5e-2f8c6d1b7a09"],
   "journey_steps": [
-    { "step": 0, "intent": "Book a Tuesday morning physical with Dr. Patel", "success_criteria": "Appointment booked and confirmation number read back" },
-    { "step": 1, "intent": "Call back to confirm the appointment", "success_criteria": "Agent confirms the existing booking" },
-    { "step": 2, "intent": "Cancel the appointment", "success_criteria": "Appointment cancelled and cancellation acknowledged" }
+    { "step": 1, "intent": "Book a Tuesday morning physical with Dr. Patel", "success_criteria": "Appointment booked and confirmation number read back" },
+    { "step": 2, "intent": "Call back to confirm the appointment", "success_criteria": "Agent confirms the existing booking" },
+    { "step": 3, "intent": "Cancel the appointment", "success_criteria": "Appointment cancelled and cancellation acknowledged" }
   ]
 }
 ```
 
-On the next run this one digital human expands into three chained calls — step 0 → 1 → 2 — each carrying the prior call's context forward so the agent sees a returning customer.
+On the next run this one digital human expands into three chained calls — step 1 → 2 → 3 — each carrying the prior call's context forward so the agent sees a returning customer.
 
 <Note>
   **`journey_steps` defines the journey.** Any digital human with a non-empty `journey_steps` array is treated as a journey and round-trips its steps on pull/push; Bluejay auto-applies the `"Customer Journey"` tag so you never have to set it by hand. Conversely, a digital human tagged `"Customer Journey"` with no steps is rejected — a journey needs at least one call.
 </Note>
 
 <Tip>
-  Push validates journeys before writing anything. Non-contiguous `step` values (e.g. `[0, 2, 5]`), duplicates, or a step with an empty `intent` come back as `valid: false` with a per-entity error and **no** changes applied. Fix the payload and push again.
+  Push validates journeys before writing anything. Non-contiguous `step` values (e.g. `[1, 3, 5]`), duplicates, or a step with an empty `intent` come back as `valid: false` with a per-entity error and **no** changes applied. Fix the payload and push again.
 </Tip>

--- a/key-concepts/bluejay-as-code/skill.mdx
+++ b/key-concepts/bluejay-as-code/skill.mdx
@@ -161,6 +161,33 @@ def push_bluejay_as_code(payload: dict, api_key: str) -> dict:
 
 ---
 
+## Customer Journeys
+
+A Customer Journey is a single digital human that makes a *sequence* of calls (same caller returning across steps, with earlier-call context carried forward). In a BaC payload it is a normal digital human with two extra fields:
+
+- `tag`: `"Customer Journey"` — optional on push; Bluejay auto-applies it whenever `journey_steps` is present.
+- `journey_steps`: an ordered array of `{ "step", "intent", "success_criteria" }`.
+
+```json
+{
+  "bluejay_as_code_id": "d4f8a2c1-6b3e-4a09-8f27-1c5e9b0d3a76",
+  "human_name": "Returning Caller",
+  "tag": "Customer Journey",
+  "simulations": ["<simulation bluejay_as_code_id>"],
+  "journey_steps": [
+    { "step": 0, "intent": "Book an appointment", "success_criteria": "Booked + confirmation number" },
+    { "step": 1, "intent": "Call back to confirm", "success_criteria": "Agent confirms the booking" }
+  ]
+}
+```
+
+**Rules (enforced on push — violations return `valid: false` with no changes applied):**
+- `journey_steps` defines the journey. Any digital human with a non-empty `journey_steps` array is a journey; an empty/missing array on a `"Customer Journey"`-tagged digital human is rejected.
+- `step` values must be **unique and contiguous starting at 0** (`0, 1, 2, …`). Non-contiguous like `[0, 2, 5]` is rejected — calls run positionally in this order.
+- Every step needs a non-empty `intent` (the caller's goal for that call). `success_criteria` is optional.
+
+---
+
 ## Full End-to-End Example
 
 ```python

--- a/key-concepts/bluejay-as-code/skill.mdx
+++ b/key-concepts/bluejay-as-code/skill.mdx
@@ -175,15 +175,15 @@ A Customer Journey is a single digital human that makes a *sequence* of calls (s
   "tag": "Customer Journey",
   "simulations": ["<simulation bluejay_as_code_id>"],
   "journey_steps": [
-    { "step": 0, "intent": "Book an appointment", "success_criteria": "Booked + confirmation number" },
-    { "step": 1, "intent": "Call back to confirm", "success_criteria": "Agent confirms the booking" }
+    { "step": 1, "intent": "Book an appointment", "success_criteria": "Booked + confirmation number" },
+    { "step": 2, "intent": "Call back to confirm", "success_criteria": "Agent confirms the booking" }
   ]
 }
 ```
 
 **Rules (enforced on push — violations return `valid: false` with no changes applied):**
 - `journey_steps` defines the journey. Any digital human with a non-empty `journey_steps` array is a journey; an empty/missing array on a `"Customer Journey"`-tagged digital human is rejected.
-- `step` values must be **unique and contiguous starting at 0** (`0, 1, 2, …`). Non-contiguous like `[0, 2, 5]` is rejected — calls run positionally in this order.
+- `step` values must be **unique and contiguous starting at 1** (`1, 2, 3, …`). Non-contiguous like `[1, 3, 5]` is rejected — calls run in this order.
 - Every step needs a non-empty `intent` (the caller's goal for that call). `success_criteria` is optional.
 
 ---


### PR DESCRIPTION
## Summary
Documents Customer Journeys in the Bluejay as Code docs (`key-concepts/bluejay-as-code/overview.mdx` and `skill.mdx`).

- A journey is a digital human with `journey_steps` — an ordered array of `{ step, intent, success_criteria }` calls (same caller returning across steps, earlier-call context carried forward).
- Covers the **`journey_steps`-defines-the-journey** rule, the auto-applied `"Customer Journey"` tag, and push-time validation (contiguous `step` numbers, required `intent`, non-empty steps).
- Includes a worked `book → confirm → cancel` JSON example.

Pairs with the middleware hardening PR on `bluejay_middleware@kk-journeys-as-code`.

## Test plan
- Markdown-only (Mintlify). Preview: `npx mint dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Customer Journeys section to the Bluejay as Code docs to show how to model multi-call flows with a single returning caller, with examples and push-time rules.

- **New Features**
  - Defines journeys as a digital human with `journey_steps` (ordered `{ step, intent, success_criteria }`); auto-applies the "Customer Journey" `tag` when `journey_steps` is present.
  - Push-time validation: `step` values must be unique and contiguous starting at 1; each step requires a non-empty `intent`; `journey_steps` must be non-empty; a "Customer Journey" with no steps is rejected; invalid payloads return `valid: false` with no changes.

<sup>Written for commit d677c9ff3e061a629386ca69f9685c1fbaa5c08e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

