### PR TITLE
BAC customer journeys update

### DIFF
--- a/key-concepts/bluejay-as-code/overview.mdx
+++ b/key-concepts/bluejay-as-code/overview.mdx
@@ -141,6 +141,23 @@ sequenceDiagram
       "language": "en"
     }
     ```
+
+    Coverage isn't limited to one-off calls. To exercise a multi-call flow with the same caller, add a digital human with a `journey_steps` array. Each step is one call, run in order:
+
+    ```json simulation.json
+    {
+      "bluejay_as_code_id": "d4f8a2c1-6b3e-4a09-8f27-1c5e9b0d3a76",
+      "human_name": "Returning Caller",
+      "simulations": ["b1a04e88-7c2f-4d23-9a5e-2f8c6d1b7a09"],
+      "journey_steps": [
+        { "step": 1, "intent": "Book a Tuesday morning physical with Dr. Patel", "success_criteria": "Appointment booked and confirmation number read back" },
+        { "step": 2, "intent": "Call back to confirm the appointment", "success_criteria": "Agent confirms the existing booking" },
+        { "step": 3, "intent": "Cancel the appointment", "success_criteria": "Appointment cancelled and cancellation acknowledged" }
+      ]
+    }
+    ```
+
+    Bluejay auto-tags this digital human `"Customer Journey"` and runs the steps in order, each call gated on the one before. `step` numbers must be unique and contiguous from `1`, and every step needs an `intent` (`success_criteria` is optional).
   </Step>
 
   <Step title="Push your changes">
@@ -224,44 +241,3 @@ assert result["valid"], result["errors"]
 for action in result["actions"]:
     print(action)
 ```
-
-## Customer Journeys
-
-A **Customer Journey** is a single digital human that places a *sequence* of calls — the same caller, returning across steps, with context from earlier calls carried into later ones. Use it to test multi-call flows like *book → confirm → cancel*, where each call depends on the state left by the one before it.
-
-In Bluejay as Code a journey is just a digital human with two extra fields:
-
-| Field | Type | Meaning |
-|---|---|---|
-| `tag` | string | `"Customer Journey"`. Marks the digital human as a journey. Optional on push — Bluejay applies it automatically whenever `journey_steps` is present. |
-| `journey_steps` | array | The ordered calls. Each step is `{ "step", "intent", "success_criteria" }`. |
-
-Each step:
-
-- **`step`** (int) — the call's position in the sequence. Step numbers must be **unique and contiguous starting at `1`** (`1, 2, 3, …`). Calls run strictly in this order, each gated until the previous one completes.
-- **`intent`** (string, **required**) — what the simulated caller is trying to do on *this* call. A step with no intent is rejected.
-- **`success_criteria`** (string, optional) — how that individual call is graded.
-
-```json simulation.json
-{
-  "bluejay_as_code_id": "d4f8a2c1-6b3e-4a09-8f27-1c5e9b0d3a76",
-  "human_name": "Returning Caller",
-  "tag": "Customer Journey",
-  "simulations": ["b1a04e88-7c2f-4d23-9a5e-2f8c6d1b7a09"],
-  "journey_steps": [
-    { "step": 1, "intent": "Book a Tuesday morning physical with Dr. Patel", "success_criteria": "Appointment booked and confirmation number read back" },
-    { "step": 2, "intent": "Call back to confirm the appointment", "success_criteria": "Agent confirms the existing booking" },
-    { "step": 3, "intent": "Cancel the appointment", "success_criteria": "Appointment cancelled and cancellation acknowledged" }
-  ]
-}
-```
-
-On the next run this one digital human expands into three chained calls — step 1 → 2 → 3 — each carrying the prior call's context forward so the agent sees a returning customer.
-
-<Note>
-  **`journey_steps` defines the journey.** Any digital human with a non-empty `journey_steps` array is treated as a journey and round-trips its steps on pull/push; Bluejay auto-applies the `"Customer Journey"` tag so you never have to set it by hand. Conversely, a digital human tagged `"Customer Journey"` with no steps is rejected — a journey needs at least one call.
-</Note>
-
-<Tip>
-  Push validates journeys before writing anything. Non-contiguous `step` values (e.g. `[1, 3, 5]`), duplicates, or a step with an empty `intent` come back as `valid: false` with a per-entity error and **no** changes applied. Fix the payload and push again.
-</Tip>

--- a/key-concepts/bluejay-as-code/skill.mdx
+++ b/key-concepts/bluejay-as-code/skill.mdx
@@ -161,33 +161,6 @@ def push_bluejay_as_code(payload: dict, api_key: str) -> dict:
 
 ---
 
-## Customer Journeys
-
-A Customer Journey is a single digital human that makes a *sequence* of calls (same caller returning across steps, with earlier-call context carried forward). In a BaC payload it is a normal digital human with two extra fields:
-
-- `tag`: `"Customer Journey"` — optional on push; Bluejay auto-applies it whenever `journey_steps` is present.
-- `journey_steps`: an ordered array of `{ "step", "intent", "success_criteria" }`.
-
-```json
-{
-  "bluejay_as_code_id": "d4f8a2c1-6b3e-4a09-8f27-1c5e9b0d3a76",
-  "human_name": "Returning Caller",
-  "tag": "Customer Journey",
-  "simulations": ["<simulation bluejay_as_code_id>"],
-  "journey_steps": [
-    { "step": 1, "intent": "Book an appointment", "success_criteria": "Booked + confirmation number" },
-    { "step": 2, "intent": "Call back to confirm", "success_criteria": "Agent confirms the booking" }
-  ]
-}
-```
-
-**Rules (enforced on push — violations return `valid: false` with no changes applied):**
-- `journey_steps` defines the journey. Any digital human with a non-empty `journey_steps` array is a journey; an empty/missing array on a `"Customer Journey"`-tagged digital human is rejected.
-- `step` values must be **unique and contiguous starting at 1** (`1, 2, 3, …`). Non-contiguous like `[1, 3, 5]` is rejected — calls run in this order.
-- Every step needs a non-empty `intent` (the caller's goal for that call). `success_criteria` is optional.
-
----
-
 ## Full End-to-End Example
 
 ```python
@@ -214,6 +187,18 @@ payload["digital_humans"].append({
     "description": "A customer who has been on hold for 20 minutes and wants a quick resolution.",
     "language": "en",
     "simulations": [payload["simulations"][0]["bluejay_as_code_id"]],
+})
+
+# 3b. Add a Customer Journey
+# Note that the journey steps are 1-indexed.
+payload["digital_humans"].append({
+    "bluejay_as_code_id": str(uuid.uuid4()),
+    "human_name": "Returning Caller",
+    "simulations": [payload["simulations"][0]["bluejay_as_code_id"]],
+    "journey_steps": [
+        {"step": 1, "intent": "Book an appointment", "success_criteria": "Booked + confirmation number"},
+        {"step": 2, "intent": "Call back to confirm", "success_criteria": "Agent confirms the booking"},
+    ],
 })
 
 # 4. Push — single unified endpoint regardless of which root_type you pulled from


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds LiveKit Observability docs (API and Web, with walkthrough videos) and streamlines Bluejay as Code Customer Journeys with `journey_steps` examples and rules; also fixes the LiveKit simulation sample to surface HTTP errors.

- **New Features**
  - New `integrations/livekit` page: API-based `/v1/evaluate` integration and Web (No Code) webhook setup, plus 4 walkthrough videos; linked in `docs.json`.
  - Bluejay as Code: consolidate Customer Journeys into `overview.mdx` and `skill.mdx` with concise `journey_steps` examples, step rules (1-indexed, unique, contiguous), and auto-tagging behavior.

- **Bug Fixes**
  - `simulation-integrations/livekit.mdx`: call `res.raise_for_status()` after `update-simulation-result` POST to catch errors.

<sup>Written for commit 6530ec985743331c985faa6786f23f8b6bae77d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

