### PR TITLE
docs(chirp): document mark playback-acknowledgment message

### DIFF
--- a/chirp_rewrite.md
+++ b/chirp_rewrite.md
@@ -304,7 +304,7 @@ A minimum-integration customer can choose to send only `binary` frames and recei
     "type": "mark",
     "id":   "uuid",
     "ts_ms": 1729123456789,
-    "data": { "name": "prompt-1" }
+    "data": { "name": "agent-greeting" }
   }
 ```
 
@@ -350,13 +350,13 @@ Illustrates every message kind in one session, covering the minimum integration,
                         "type": "mark",
                         "id": "cust-mark-0001",
                         "ts_ms": 1729123457000,
-                        "data": { "name": "prompt-1" }
+                        "data": { "name": "agent-greeting" }
                       }
 [Bluejay -> Customer] text {                # ~queued_duration later, when drained
                         "type": "mark",
                         "id": "b1-mark-0001",
                         "ts_ms": 1729123457260,
-                        "data": { "name": "prompt-1" }
+                        "data": { "name": "agent-greeting" }
                       }
 
 # 3. LiveKit voice agent responds. We emit speech events + binary.
@@ -551,10 +551,10 @@ sequenceDiagram
     C->>B: binary <pcm 20ms>
     C->>B: binary <pcm 20ms>
     Note over B: frames captured into AudioSource (queued_duration = T)
-    C->>B: text { type mark, data { name "prompt-1" } }
+    C->>B: text { type mark, data { name "agent-greeting" } }
     Note over B: read queued_duration = T; schedule echo in T seconds
     Note over B: ...audio plays out to the agent...
-    B->>C: text { type mark, data { name "prompt-1" } }
+    B->>C: text { type mark, data { name "agent-greeting" } }
     Note over C: matched by name -> start silence / interruption timing
 ```
 

--- a/chirp_rewrite.md
+++ b/chirp_rewrite.md
@@ -35,6 +35,9 @@ todos:
   - id: spec-doc
     content: Write the one-page customer-facing CHIRP spec doc emphasizing the zero-JSON minimum integration
     status: pending
+  - id: mark-message
+    content: Add MessageType.MARK ("mark") + mark(name) builder + require_name() to chirp_message.py; on customer mark, echo the same name after audio_source.queued_duration drains; cancel pending echoes on barge-in/stop; mirror in tests/websocket_server.py. Playback-acknowledgment ack requested by RASA (replaces Twilio media-stream marks). Name-only; no streamSid/sequenceNumber/nesting.
+    status: pending
 isProject: false
 ---
 
@@ -141,6 +144,7 @@ Customers with their own VAD or push-to-talk source can send speech events for t
 | `speech.started` while we are mid-utterance | We immediately stop sending agent audio, call LiveKit's agent interrupt API, emit `speech.completed` for the canceled utterance, switch to listening |
 | `speech.started` when we are idle           | Informational; logged. LiveKit's VAD will trigger the agent off the audio anyway                                                                     |
 | `speech.completed`                          | Informational; can shave VAD-tail-padding latency by signaling end-of-turn explicitly                                                                |
+| `mark` after sending audio                  | We echo a `mark` with the same `name` once that audio has played out into the agent's listening pipeline — a playback-completion acknowledgment      |
 
 
 There is no separate `interrupt` message. Sending `speech.started` while we are speaking *is* the interrupt.
@@ -149,7 +153,7 @@ There is no separate `interrupt` message. Sending `speech.started` while we are 
 
 ## Protocol reference (the full wire vocabulary)
 
-The entire protocol consists of **four message kinds** exchanged over the WebSocket. Everything else is implied.
+The entire protocol consists of **five message kinds** exchanged over the WebSocket. Everything else is implied.
 
 ### Summary table
 
@@ -160,6 +164,7 @@ The entire protocol consists of **four message kinds** exchanged over the WebSoc
 | `speech.started`   | `text` JSON   | **Automatic**, sent by us when LiveKit agent starts TTS   | **Optional.** If sent, acts as interrupt if agent is mid-utterance        |
 | `speech.completed` | `text` JSON   | **Automatic**, sent by us when LiveKit agent finishes TTS | **Optional.** Informational end-of-turn hint                              |
 | `session.error`    | `text` JSON   | Sent by us on customer's protocol violation               | Sent by customer on our protocol violation, or server-side trouble        |
+| `mark`             | `text` JSON   | **Echo only** — returned with the same `name` once the customer's pre-mark audio has played out | **Optional.** Playback-acknowledgment checkpoint; we echo it back when that audio is heard |
 
 
 A minimum-integration customer can choose to send only `binary` frames and receive only `binary` frames. They never have to parse or emit any JSON.
@@ -287,6 +292,32 @@ A minimum-integration customer can choose to send only `binary` frames and recei
 
 ---
 
+### Message 5 — `mark`
+
+- **WS frame type**: `text`
+- **Both directions** — customer sends a checkpoint, we echo it.
+- **Required**: never. Opt-in playback acknowledgment. Minimum-integration customers never use it.
+- **Shape**:
+
+```json
+  {
+    "type": "mark",
+    "id":   "uuid",
+    "ts_ms": 1729123456789,
+    "data": { "name": "prompt-1" }
+  }
+```
+
+- **Required fields inside `data`**: `name` (string) — a free-form label the customer picks, echoed back verbatim so they can match the ack to what they sent.
+- **Semantics** (a playback-completion acknowledgment — the CHIRP equivalent of a Twilio Media Streams `mark`):
+  - **Customer -> Bluejay**: "Acknowledge once the audio I sent *before* this mark has been played out." Because frames and text share one ordered receive loop, every binary frame before the mark is already captured into LiveKit's `AudioSource` by the time we see the mark. We read `audio_source.queued_duration` (seconds still buffered) at that instant and echo a `mark` with the same `name` after that much time has elapsed — i.e. when that audio has actually been heard by the agent. If nothing is buffered, we echo immediately.
+  - **Bluejay -> Customer**: the echo. Same `data.name`, fresh `id` / `ts_ms`. We do **not** originate marks on our own (agent TTS) audio in v1 — we only echo customer marks.
+- **What we intentionally do not carry** (Twilio-specific, unnecessary here): `streamSid` (one WebSocket *is* one session), `sequenceNumber` (the envelope's `id` + `ts_ms` already order and uniquely identify frames), and the nested `mark{}` wrapper (flattened to `data.name`).
+- **Interaction with barge-in**: barge-in does not affect mark echoes. A customer `speech.started` interrupts the *agent's outbound* speech (via the LiveKit interrupt path); it never clears the customer→agent audio buffer that marks are timed against, so pending echoes still complete normally. Only session teardown cancels them, and an echo that fires after the WebSocket has closed is a harmless no-op.
+- **Use case**: lets the customer's agent know exactly when its audio finished playing, which is what drives silence-detection timers and interruption handling on their side.
+
+---
+
 ### utterance_id
 
 A free-form string (UUID, timestamp, counter — anything unique within the session). Used to match `speech.started` to its `speech.completed`. Server-minted for events we send. Customer mints their own for events they send. Customers using the minimum integration never see or generate one.
@@ -312,6 +343,21 @@ Illustrates every message kind in one session, covering the minimum integration,
 [Customer -> Bluejay] binary <640 bytes>
 [Customer -> Bluejay] binary <640 bytes>
 [Customer -> Bluejay] binary <640 bytes>   # user pauses here; LiveKit VAD fires
+
+# 2b. (Advanced, opt-in) Customer marks the audio it just sent.
+#     We echo it once that audio has played out into the agent's pipeline.
+[Customer -> Bluejay] text {
+                        "type": "mark",
+                        "id": "cust-mark-0001",
+                        "ts_ms": 1729123457000,
+                        "data": { "name": "prompt-1" }
+                      }
+[Bluejay -> Customer] text {                # ~queued_duration later, when drained
+                        "type": "mark",
+                        "id": "b1-mark-0001",
+                        "ts_ms": 1729123457260,
+                        "data": { "name": "prompt-1" }
+                      }
 
 # 3. LiveKit voice agent responds. We emit speech events + binary.
 [Bluejay -> Customer] text {
@@ -398,6 +444,7 @@ Illustrates every message kind in one session, covering the minimum integration,
 | Unknown `type` value                                  | Recoverable | Send `session.error { code: INVALID_MESSAGE }`, drop the frame (forward-compat for new types) |
 | `speech.started` missing `data.utterance_id`          | Recoverable | Send `session.error { code: MISSING_FIELD }`, drop                                            |
 | `speech.completed` for an unknown utterance_id        | Recoverable | Log warning, ignore                                                                           |
+| `mark` missing `data.name`                            | Recoverable | Send `session.error { code: MISSING_FIELD }`, drop                                            |
 | Binary frame with odd byte length (not int16-aligned) | Recoverable | Send `session.error { code: INVALID_AUDIO_FRAME }`, drop                                      |
 | Customer closes the WS gracefully                     | Normal end  | Tear down LiveKit session; status based on call completion                                    |
 | Customer's WS dies (network drop, server crash)       | Fatal       | Catch `ConnectionClosed`, set `INCOMPLETED`, end LiveKit session                              |
@@ -490,6 +537,25 @@ sequenceDiagram
     C->>B: binary <pcm 20ms>
     C->>B: binary <pcm 20ms>
     C->>B: text { type speech.completed, data { utterance_id u_user } }
+```
+
+
+
+### Mark acknowledgment (opt-in playback ack)
+
+```mermaid
+sequenceDiagram
+    participant C as Customer (WS server)
+    participant B as Bluejay (WS client)
+
+    C->>B: binary <pcm 20ms>
+    C->>B: binary <pcm 20ms>
+    Note over B: frames captured into AudioSource (queued_duration = T)
+    C->>B: text { type mark, data { name "prompt-1" } }
+    Note over B: read queued_duration = T; schedule echo in T seconds
+    Note over B: ...audio plays out to the agent...
+    B->>C: text { type mark, data { name "prompt-1" } }
+    Note over C: matched by name -> start silence / interruption timing
 ```
 
 

--- a/simulation-integrations/websockets.mdx
+++ b/simulation-integrations/websockets.mdx
@@ -611,9 +611,9 @@ sequenceDiagram
     C->>B: binary (audio)
     C->>B: binary (audio)
     C->>B: text  mark {name: "agent-greeting"}
-    Note over B: echoes once the audio before the mark has played out
+    Note over B: Receives mark message and sends back a mark acknowledgement message
     B->>C: text  mark {name: "agent-greeting"}
-    Note over C: matched by name, starts silence / interruption timing
+    Note over C: Receives mark acknowledgement, matched by name, and processes timing
 ```
 
 | Behavior | Detail |

--- a/simulation-integrations/websockets.mdx
+++ b/simulation-integrations/websockets.mdx
@@ -35,7 +35,7 @@ Bluejay supports real-time, bidirectional voice over WebSocket using **CHIRP**, 
 
 [**CHIRP**](/glossary#c) (Conversational Handoff for Inter‑agent Realtime Protocol) is a novel real-time A2A communication protocol, enabling conversational agents to interact over websockets over a standard medium of communication.
 
-The bare minimum integration is accepting a WebSocket connection, validating auth, and exchanging raw PCM binary frames. The three text event types (`speech.started`, `speech.completed`, `session.error`) are all **optional** from your side. Bluejay sends them automatically, but your server can safely ignore every text frame and still have a fully working integration.
+The bare minimum integration is accepting a WebSocket connection, validating auth, and exchanging raw PCM binary frames. The four text event types (`speech.started`, `speech.completed`, `session.error`, `mark`) are all **optional** from your side. Bluejay sends `speech.started` / `speech.completed` automatically and echoes any `mark` you send, but your server can safely ignore every text frame and still have a fully working integration.
 
 ### When to use WebSocket
 
@@ -56,6 +56,7 @@ For other connection types, check out our [other integrations](/simulation-integ
 - **Minimum server**: accept WS, validate Basic auth, read binary, write binary.
 - **Text events** are optional from your side. Bluejay emits `speech.started` / `speech.completed` around Digital Human utterances — **not strictly bracketed**, see [Event ordering](#event-ordering).
 - **Barge-in**: send `speech.started` while the Digital Human is speaking.
+- **Playback acks**: send a `mark` after your audio; Bluejay echoes the same `mark` back once that audio has played out. See [Playback acknowledgments](#playback-acknowledgments).
 - **Hang up**: close the WebSocket with code `1000`.
 
 ---
@@ -413,6 +414,29 @@ Reports a protocol violation or server-side issue. This is part of the CHIRP pro
 
 Recoverable errors (all except `INTERNAL_ERROR`) do not close the connection. The offending frame is dropped and the session continues.
 </Tab>
+<Tab title="mark (optional)">
+A playback acknowledgment. Sent as a WebSocket text frame (UTF-8 JSON).
+
+```json
+{
+  "type":  "mark",
+  "id":    "d4f2a8c1-3b7e-4a90-9c2f-1e6b0a5d7c34",
+  "ts_ms": 1729123457000,
+  "data":  { "name": "prompt-1" }
+}
+```
+
+| Field   | Type    | Required | Notes                                                                               |
+| ------- | ------- | -------- | ----------------------------------------------------------------------------------- |
+| `type`  | string  | Yes      | `"mark"`                                                                            |
+| `id`    | string  | Yes      | UUID (auto-filled by Bluejay if omitted)                                            |
+| `ts_ms` | integer | Yes      | Unix epoch ms (auto-filled if omitted)                                              |
+| `name`  | string  | Yes      | Your own label, echoed back verbatim so you can match the ack to the audio you sent |
+
+**You send this** after a chunk of audio you want acknowledged. Bluejay echoes a `mark` with the same `name` once all audio you sent before it has played out to the Digital Human. Use it for playback-completion timing, such as starting a silence timer or detecting an interruption.
+
+**Bluejay sends this** only as an echo of a `mark` you sent. Bluejay does not originate marks on its own audio. See [Playback acknowledgments](#playback-acknowledgments).
+</Tab>
 </Tabs>
 
 ---
@@ -519,6 +543,10 @@ sequenceDiagram
 [Server   -> Bluejay] binary <640 B>
 [Server   -> Bluejay] binary <640 B>
 
+# 2b. (Optional) You mark the audio you just sent; Bluejay echoes it once that audio has played out.
+[Server   -> Bluejay] text   {"type":"mark","data":{"name":"user-turn-1"}, ...}
+[Bluejay  -> Server]  text   {"type":"mark","data":{"name":"user-turn-1"}, ...}
+
 # 3. Digital Human responds.
 #    Note: speech.started arrives AFTER the first few audio frames (VAD analysis window),
 #    and speech.completed arrives BEFORE the last few audio frames (VAD end-of-speech
@@ -566,3 +594,31 @@ sequenceDiagram
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Digital Human is mid-utterance        | Stops sending audio, interrupts the Digital Human, emits `speech.completed` for the canceled utterance, listens |
 | Digital Human is idle                 | Informational. Bluejay picks up user audio from binary frames regardless.                                      |
+
+---
+
+## Playback acknowledgments
+
+If your server needs to know when audio it sent has finished playing to the Digital Human, send a `mark` text frame right after that audio. Bluejay echoes a `mark` with the same `name` once all audio you sent before it has played out. This mirrors the playback-acknowledgment pattern from telephony media streams, reduced to a single matching field.
+
+Use it to drive silence-detection timers, measure round-trip playback latency, or coordinate interruption handling.
+
+```mermaid
+sequenceDiagram
+    participant C as Your server
+    participant B as Bluejay
+
+    C->>B: binary (audio)
+    C->>B: binary (audio)
+    C->>B: text  mark {name: "prompt-1"}
+    Note over B: echoes once the audio before the mark has played out
+    B->>C: text  mark {name: "prompt-1"}
+    Note over C: matched by name, starts silence / interruption timing
+```
+
+| Behavior | Detail |
+| -------- | ------ |
+| When Bluejay echoes | Once all audio you sent before the `mark` has played out to the Digital Human. If nothing is buffered, the echo is near-immediate. |
+| Matching | Match on `data.name`. The echo is a new frame with its own `id` and `ts_ms`, so do not match on `id`. |
+| `name` semantics | Opaque to Bluejay and echoed back unchanged. You choose its meaning (a turn id, a counter, a label). |
+| Optional | Minimum-integration servers never send or receive marks. Bluejay only echoes marks you send; it does not emit marks for the Digital Human's own audio. |

--- a/simulation-integrations/websockets.mdx
+++ b/simulation-integrations/websockets.mdx
@@ -422,7 +422,7 @@ A playback acknowledgment. Sent as a WebSocket text frame (UTF-8 JSON).
   "type":  "mark",
   "id":    "d4f2a8c1-3b7e-4a90-9c2f-1e6b0a5d7c34",
   "ts_ms": 1729123457000,
-  "data":  { "name": "prompt-1" }
+  "data":  { "name": "agent-greeting" }
 }
 ```
 
@@ -610,9 +610,9 @@ sequenceDiagram
 
     C->>B: binary (audio)
     C->>B: binary (audio)
-    C->>B: text  mark {name: "prompt-1"}
+    C->>B: text  mark {name: "agent-greeting"}
     Note over B: echoes once the audio before the mark has played out
-    B->>C: text  mark {name: "prompt-1"}
+    B->>C: text  mark {name: "agent-greeting"}
     Note over C: matched by name, starts silence / interruption timing
 ```
 


### PR DESCRIPTION
## What
Documents `mark` as the fifth CHIRP v2 message kind in the redesign spec (`chirp_rewrite.md`):
- summary-table row
- full "Message 5 — mark" section: shape, both-direction semantics, echo timing via `audio_source.queued_duration`, dropped Twilio fields, barge-in behavior
- sample-flow step + error-table row
- mark-acknowledgment sequence diagram

## Why
RASA requested Twilio-style playback acknowledgments for silence-detection and interruption testing. Implementation lives in the livekit_agent repo (separate PR).

## Note
The customer-facing page `simulation-integrations/websockets.mdx` still needs the `mark` section added (it currently states no mark frames are defined). Not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `mark` as the fifth CHIRP v2 message type for playback acknowledgments. Documents the JSON shape and echo timing via `audio_source.queued_duration`, and updates the WebSocket guide with examples and clarified sequence-diagram notes.

- **New Features**
  - CHIRP spec: Added `mark` to the summary table and a new Message 5 section with required `data.name`, echo-only semantics, precise timing via `audio_source.queued_duration`, barge-in does not cancel pending echoes, Twilio field exclusions, a sample-flow step, an error-table row, and an ack sequence diagram with clearer note boxes.
  - Customer WebSocket guide: Updated event count to include `mark`; added a quick-reference bullet, a `mark` message-format tab (JSON + field notes, `id`/`ts_ms` auto-fill), a sample-session exchange, and a Playback acknowledgments section with a sequence diagram. Examples use `"agent-greeting"` consistently.

<sup>Written for commit e57514a754ce703946c3de021d2fa7a92a914357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

