### PR TITLE
Document Bluejay AI assistant and Skills

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -106,6 +106,15 @@
             "icon": "lightbulb",
             "pages": [
               {
+                "group": "Bluejay AI",
+                "icon": "comments",
+                "expanded": false,
+                "pages": [
+                  "key-concepts/bluejay-ai/overview",
+                  "key-concepts/bluejay-ai/skills"
+                ]
+              },
+              {
                 "group": "Agents",
                 "icon": "robot",
                 "expanded": false,

--- a/key-concepts/bluejay-ai/overview.mdx
+++ b/key-concepts/bluejay-ai/overview.mdx
@@ -1,0 +1,54 @@
+---
+title: Overview
+description: Bluejay AI is the in-app assistant that runs the platform for you
+icon: comments
+---
+
+Bluejay AI is an assistant built into the app. Unlike a plain chatbot, it can **take actions on your behalf** — create digital humans, queue simulation runs, analyze results, query production call logs, and edit agent configuration — instead of just telling you how to do them.
+
+## What You'll Learn
+
+- What Bluejay AI can do and how it differs from a Q&A chatbot
+- How to talk to it and reference your agents, simulations, and metrics
+- What Skills are and how to run one
+
+## What Bluejay AI Can Do
+
+Ask in plain language and Bluejay AI carries the task through end to end:
+
+- **Build test inputs** — generate digital human personas, attach them to a simulation, and tune their goals.
+- **Run tests** — queue voice or SMS simulation runs and report results when they finish.
+- **Analyze** — summarize a run, compare two runs, triage failures, and dig into a single transcript.
+- **Monitor production** — query your live call logs and surface volume, failures, latency, and language mix.
+- **Configure** — create and edit agents, dashboards, custom metrics, and workflow branches.
+
+It **acts rather than instructs**: if a task can be done, it does it and reports back. For ambiguous or irreversible actions it pauses to confirm before proceeding.
+
+## Working With Context
+
+Bluejay AI is aware of what you have open and selected in the app, so you rarely have to spell things out:
+
+- **References** — mention an agent, simulation, digital human, or custom metric directly and the assistant uses that exact object.
+- **Current selection** — say "this run" or "the selected agent" and it resolves from your current page.
+- **Confirmation** — before anything destructive (deleting records) or anything that goes live (pushing a workflow to your provider), it shows you what it will do and waits for your go-ahead.
+
+## Skills
+
+For common, multi-step jobs, Bluejay AI ships with **Skills** — one-command workflows like "run a red-team sweep" or "build a persona suite" that the assistant executes step by step. Type `/` in the assistant to browse them, or just describe what you want.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Skills" icon="wand-magic-sparkles" href="/key-concepts/bluejay-ai/skills">
+    Browse the full catalog of Skills you can run.
+  </Card>
+  <Card title="Digital Humans" icon="users" href="/key-concepts/digital-humans/overview">
+    The synthetic personas Bluejay AI creates to test your agents.
+  </Card>
+  <Card title="Custom Metrics" icon="gauge-high" href="/key-concepts/custom-metrics/overview">
+    The evals Bluejay AI builds and scores runs against.
+  </Card>
+  <Card title="Observability" icon="eye" href="/key-concepts/observability/overview">
+    The production data Bluejay AI can query for you.
+  </Card>
+</CardGroup>

--- a/key-concepts/bluejay-ai/skills.mdx
+++ b/key-concepts/bluejay-ai/skills.mdx
@@ -1,0 +1,97 @@
+---
+title: Skills
+description: One-command workflows you can run inside the Bluejay AI assistant
+icon: wand-magic-sparkles
+---
+
+Skills are packaged, multi-step workflows that [Bluejay AI](/key-concepts/bluejay-ai/overview) runs end to end. Instead of walking the assistant through "create personas, attach them, queue a run, then summarize," you invoke a single Skill and it carries out every step for you.
+
+## What You'll Learn
+
+- How to run a Skill
+- The full catalog of available Skills
+- How Skills handle confirmation and your current context
+
+## Running a Skill
+
+<Steps>
+  <Step title="Open Bluejay AI">
+    Open the Bluejay AI assistant in the app.
+  </Step>
+  <Step title="Invoke a Skill">
+    Type <code>/</code> to open the Skill picker and choose one, or simply describe what you want in plain language (for example, "run a red-team sweep on my support agent"). Bluejay AI matches your request to the right Skill automatically.
+  </Step>
+  <Step title="Fill in the specifics">
+    The assistant uses your selected agent and other context where it can, and asks you only for what it genuinely needs.
+  </Step>
+  <Step title="Let it run">
+    The Skill executes step by step. Simulation runs take a few minutes — Bluejay AI reports the results once they complete.
+  </Step>
+</Steps>
+
+Skills are guidance, not rigid scripts: the assistant skips steps that are already satisfied, and pauses to confirm before any destructive action (deleting records) or anything that goes live (pushing a workflow to your provider).
+
+## Catalog
+
+### Setup & personas
+
+| Skill | Command | What it does |
+|-------|---------|--------------|
+| Onboard a new agent | `/agent-onboard` | Create a new agent and immediately smoke-test it. |
+| Smoke-test a new agent | `/new-agent-smoke-test` | Quick sanity simulation to confirm a fresh agent works. |
+| Build a persona suite | `/persona-suite` | Turn a plain-English brief into a diverse set of digital humans. |
+
+### Running tests
+
+| Skill | Command | What it does |
+|-------|---------|--------------|
+| Run a simulation | `/run-simulation` | Queue a voice simulation run and report results. |
+| Run an SMS / text simulation | `/sms-simulation` | Run a text-channel simulation against an SMS or chat agent. |
+| Load-test an agent | `/load-test` | Stress the agent with many concurrent calls and report degradation. |
+| Schedule a recurring simulation | `/schedule-sim` | Run a simulation automatically on a cadence. |
+| Red-team sweep | `/red-team-sweep` | Probe the agent with adversarial callers and report vulnerabilities. |
+
+### Evals & metrics
+
+| Skill | Command | What it does |
+|-------|---------|--------------|
+| Build a custom metric / eval | `/custom-metric-builder` | Turn a quality bar into custom metrics that score runs. |
+
+### Results & comparison
+
+| Skill | Command | What it does |
+|-------|---------|--------------|
+| Report on a run | `/run-report` | Detailed pass rate, per-metric scores, and failing cases for one run. |
+| Compare two runs | `/compare-runs` | Diff two runs at the metric and case level. |
+| Regression check | `/agent-regression` | Re-run and compare to the last run, flagging any regressions. |
+| Deep-dive a transcript | `/transcript-deep-dive` | Analyze a single call turn by turn and recommend a fix. |
+| Agent scorecard | `/agent-scorecard` | One health snapshot across recent tests and production. |
+
+### Production analysis
+
+| Skill | Command | What it does |
+|-------|---------|--------------|
+| Production pulse | `/production-pulse` | Snapshot of live call volume, status mix, and durations. |
+| Triage failed calls | `/failed-call-triage` | Cluster failed production calls by failure mode and propose fixes. |
+| Triage latency | `/latency-triage` | Find where response time is going and which calls are slowest. |
+| Audit call languages | `/language-audit` | Break calls down by language and flag where the agent struggles. |
+
+### Coverage, config & dashboards
+
+| Skill | Command | What it does |
+|-------|---------|--------------|
+| Audit test coverage | `/coverage-audit` | Find workflow branches no persona currently tests. |
+| Find knowledge gaps | `/knowledge-gap` | Surface questions the agent fumbled and what to add to the KB. |
+| Add a workflow branch | `/workflow-branch` | Add a node and transition to an agent's workflow (push live on confirmation). |
+| Build a dashboard | `/build-dashboard` | Assemble an observability dashboard with the key widgets. |
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Bluejay AI Overview" icon="comments" href="/key-concepts/bluejay-ai/overview">
+    What the in-app assistant is and how it works.
+  </Card>
+  <Card title="Simulations" icon="flask-vial" href="/key-concepts/simulations/overview">
+    The tests many Skills create, run, and analyze.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## What

Documents the in-app **Bluejay AI** assistant and its new **Skills** feature. New "Bluejay AI" group under **Key Concepts** with two pages:

- **Overview** (`key-concepts/bluejay-ai/overview`) — what the assistant is, that it *takes actions* (not just answers), how it uses your selected context, and its confirm-before-destructive behavior.
- **Skills** (`key-concepts/bluejay-ai/skills`) — how to run a Skill (type `/` to pick, or ask in plain language) plus the full catalog of all 22 Skills, grouped (setup & personas, running tests, evals, results & comparison, production analysis, coverage/config/dashboards).

Product-level language only — no implementation detail. Pairs with the frontend feature in [bluejay_frontend_v2#850](https://github.com/bluejay-ai-dev/bluejay_frontend_v2/pull/850).

## Verification

- `docs.json` is valid JSON; new "Bluejay AI" group renders at the top of Key Concepts.
- `mint broken-links`: zero broken links in the new pages (the 14 it reports are all pre-existing, in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation for the in‑app Bluejay AI assistant and its new Skills, including a new “Bluejay AI” group under Key Concepts. Explains how the assistant takes actions using your current context and provides a catalog of 22 Skills with how to run them.

- **New Features**
  - New “Bluejay AI” group in Key Concepts with:
    - `key-concepts/bluejay-ai/overview` — what the assistant can do, how it uses your selection, and confirm‑before‑destructive behavior.
    - `key-concepts/bluejay-ai/skills` — how to run a Skill (`/` picker or plain language) and the full catalog of 22 Skills grouped by area (setup/personas, running tests, evals, results/comparison, production analysis, coverage/config/dashboards).

<sup>Written for commit 01265bfc796e0bd0d8ee05da8386b35f7a5998bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

