### PR TITLE
Docs/alerts overview rewrite

### DIFF
--- a/core-concepts/communities.mdx
+++ b/core-concepts/communities.mdx
@@ -4,11 +4,11 @@ description: 'Learn about Bluejay Communities'
 icon: people-group
 ---
 
-**Communities** in Bluejay are collections of Digital Humans designed to help you organize, manage, and reuse realistic test scenarios across multiple agents and experiments. They act as an efficient way to group related Digital Humans -- such as those focused on specific customer types, languages, or goals -- so you can quickly run consistent sets of tests whenever and wherever you need.
+**Communities** in Bluejay are collections of Digital Humans designed to help you organize, manage, and reuse realistic test scenarios across multiple agents and experiments. They act as an efficient way to group related Digital Humans, such as those focused on specific customer types, languages, or goals, so you can quickly run consistent sets of tests whenever and wherever you need.
 
 ## What Is a Community?
 
-A **Community** is a named and described group of Digital Humans that share a common purpose or testing focus. Communities allow you to manage your testing personas in a structured, repeatable way—ideal for running the same set of Digital Humans across different agents or evaluation cycles.
+A **Community** is a named and described group of Digital Humans that share a common purpose or testing focus. Communities allow you to manage your testing personas in a structured, repeatable way, ideal for running the same set of Digital Humans across different agents or evaluation cycles.
 
 For example, you might create a *“Spanish Support Callers”* community to test how different agents handle multilingual customer interactions, or a *“Difficult Customers”* community to stress-test escalation and empathy handling.
 

--- a/key-concepts/alerts/overview.mdx
+++ b/key-concepts/alerts/overview.mdx
@@ -41,11 +41,15 @@ Bluejay uses threshold alerts that count how many times a metric crosses a bound
 
 ```mermaid
 flowchart LR
-    Metric[Metric Watched] --> Threshold[Threshold Crossed]
-    Threshold --> Window[Window Reached]
-    Window --> Fire[Alert Fires]
-    Fire --> Notify[Slack / Email]
-    Fire --> Badge[Dashboard Badge]
+    Eval[Call or Simulation Evaluated] --> Score[Metric Scored]
+    Score --> Cross{Score Crosses Boundary?}
+    Cross -->|No| OK[No Violation]
+    Cross -->|Yes| Count[Violation Counted]
+    Count --> Window{"Enough Violations\nin Time Window?"}
+    Window -->|No| Wait[Continue Monitoring]
+    Window -->|Yes| Fire[Alert Triggered]
+    Fire --> Notify[Slack / Email Notification]
+    Fire --> Badge[Alert Badge on Dashboard]
 ```
 
 ## Anatomy of an Alert

--- a/key-concepts/alerts/overview.mdx
+++ b/key-concepts/alerts/overview.mdx
@@ -40,12 +40,13 @@ Click each scenario to see what an alert is watching for.
 Bluejay uses threshold alerts that count how many times a metric crosses a boundary within a rolling time window. The alert only fires when the violation count reaches the required number of occurrences. This filters out noise while catching sustained problems.
 
 ```mermaid
+%%{init: {"flowchart": {"useMaxWidth": true, "nodeSpacing": 60, "rankSpacing": 70}, "themeVariables": {"fontSize": "20px"}}}%%
 flowchart LR
     Eval[Call or Simulation Evaluated] --> Score[Metric Scored]
     Score --> Cross{Score Crosses Boundary?}
     Cross -->|No| OK[No Violation]
     Cross -->|Yes| Count[Violation Counted]
-    Count --> Window{"Enough Violations\nin Time Window?"}
+    Count --> Window{"Enough Violations<br/>in Time Window?"}
     Window -->|No| Wait[Continue Monitoring]
     Window -->|Yes| Fire[Alert Triggered]
     Fire --> Notify[Slack / Email Notification]

--- a/key-concepts/alerts/overview.mdx
+++ b/key-concepts/alerts/overview.mdx
@@ -40,17 +40,12 @@ Click each scenario to see what an alert is watching for.
 Bluejay uses threshold alerts that count how many times a metric crosses a boundary within a rolling time window. The alert only fires when the violation count reaches the required number of occurrences. This filters out noise while catching sustained problems.
 
 ```mermaid
-%%{init: {"flowchart": {"useMaxWidth": true, "nodeSpacing": 60, "rankSpacing": 70}, "themeVariables": {"fontSize": "20px"}}}%%
 flowchart LR
-    Eval[Call or Simulation Evaluated] --> Score[Metric Scored]
-    Score --> Cross{Score Crosses Boundary?}
-    Cross -->|No| OK[No Violation]
-    Cross -->|Yes| Count[Violation Counted]
-    Count --> Window{"Enough Violations<br/>in Time Window?"}
-    Window -->|No| Wait[Continue Monitoring]
-    Window -->|Yes| Fire[Alert Triggered]
-    Fire --> Notify[Slack / Email Notification]
-    Fire --> Badge[Alert Badge on Dashboard]
+    Metric[Metric Watched] --> Threshold[Threshold Crossed]
+    Threshold --> Window[Window Reached]
+    Window --> Fire[Alert Fires]
+    Fire --> Notify[Slack / Email]
+    Fire --> Badge[Dashboard Badge]
 ```
 
 ## Anatomy of an Alert

--- a/key-concepts/alerts/overview.mdx
+++ b/key-concepts/alerts/overview.mdx
@@ -4,17 +4,40 @@ description: Understand how Alerts are configured and used in Bluejay
 icon: bell
 ---
 
-Alerts notify your team when monitored conversations or metrics cross a threshold that needs attention. They help you move from passive reporting to active operational response.
+Alerts are Bluejay's way of notifying you the moment something important changes in your live production traffic. They sit alongside dashboards and logs as the third observability surface in Bluejay. Dashboards help you explore trends, logs help you inspect individual calls, and alerts tell you when you should pay attention right now.
 
 ## What You'll Learn
 
 - What Alerts are and how they fit into monitoring workflows
-- How to configure threshold-based notifications
-- How Alerts connect to Slack and other integrations
+- The parts that make up a Bluejay alert
+- The lifecycle of an alert from monitoring through resolution
+- How to configure threshold-based notifications and connect them to Slack
+
+## What Alerts Help You Catch
+
+Click each scenario to see what an alert is watching for.
+
+<AccordionGroup>
+  <Accordion title="Spikes in failed calls" icon="circle-xmark">
+    A sudden rise in the number of calls that fail or terminate unexpectedly. Useful for catching deployment regressions, broken tool calls, or upstream provider outages.
+  </Accordion>
+  <Accordion title="Drops in call volume" icon="chart-line-down">
+    A sharp decrease in the number of calls coming through. Often indicates an upstream routing issue, a misconfigured phone number, or an integration outage.
+  </Accordion>
+  <Accordion title="Latency getting worse" icon="gauge-simple-high">
+    Response times trending upward across calls. Indicates degraded performance from your agent, your LLM provider, or your downstream APIs.
+  </Accordion>
+  <Accordion title="Quality metrics degrading" icon="circle-exclamation">
+    Custom metric pass rates dropping below their expected baseline. Catches behavior regressions before customers escalate.
+  </Accordion>
+  <Accordion title="Unusual behavior for a specific agent" icon="user-shield">
+    Anomalous activity scoped to one agent, such as hallucinations or off-script behavior. Set a tight threshold and route the alert to the team responsible for that agent.
+  </Accordion>
+</AccordionGroup>
 
 ## How Alerts Work
 
-Bluejay uses threshold alerts that count how many times a metric crosses a boundary within a rolling time window. The alert only fires when the violation count reaches the required number of occurrences — filtering out noise while catching sustained problems.
+Bluejay uses threshold alerts that count how many times a metric crosses a boundary within a rolling time window. The alert only fires when the violation count reaches the required number of occurrences. This filters out noise while catching sustained problems.
 
 ```mermaid
 flowchart LR
@@ -29,6 +52,28 @@ flowchart LR
     Fire --> Badge[Alert Badge on Dashboard]
 ```
 
+## Anatomy of an Alert
+
+A Bluejay alert is made up of five parts. Click each to expand.
+
+<AccordionGroup>
+  <Accordion title="The metric it watches" icon="gauge-high">
+    The Custom Metric or built-in observability metric the alert monitors. For example, call count, latency, failure rate, or a quality metric you defined.
+  </Accordion>
+  <Accordion title="The threshold" icon="ruler-horizontal">
+    The numeric boundary that counts as a violation. Expressed as "above X" or "below Y", for example "above 3 seconds" for a latency alert.
+  </Accordion>
+  <Accordion title="The time window" icon="clock">
+    The rolling interval over which Bluejay counts violations. Common windows are 5 minutes, 1 hour, or a day, depending on the metric's volatility.
+  </Accordion>
+  <Accordion title="The scope" icon="bullseye">
+    Whether the alert watches every agent in the workspace or a specific agent. Scope alerts narrowly when an agent has unusual baselines that a workspace-wide rule would not catch.
+  </Accordion>
+  <Accordion title="The notification behavior" icon="bell">
+    What happens when the alert triggers, when it resolves, and where the notification is delivered (Slack channel, email, or dashboard badge).
+  </Accordion>
+</AccordionGroup>
+
 ### Threshold Alert Configuration
 
 When creating a threshold alert, you configure the metric to watch, the boundary condition, and the sensitivity of the trigger:
@@ -41,26 +86,61 @@ When creating a threshold alert, you configure the metric to watch, the boundary
 | **Occurrences** | How many violations must occur before the alert fires | 5 |
 | **Time Window** | The rolling interval over which violations are counted | 10 minutes |
 
-For example, an alert on "Average Agent Latency > 3 seconds" with 5 occurrences in a 10-minute window will only fire when 5 calls exceed 3-second latency within that window. A single slow call won't trigger a notification — but a sustained regression will.
+<Tip>
+**Example.** An alert on "Average Agent Latency > 3 seconds" with 5 occurrences in a 10-minute window will only fire when 5 calls exceed 3-second latency within that window. A single slow call won't trigger a notification, but a sustained regression will.
 
 For critical metrics like hallucination detection, set occurrences to 1 so the alert fires on the very first violation.
+</Tip>
+
+## Alert Lifecycle
+
+Every alert moves through three states. Click each to see what happens at that stage.
+
+<AccordionGroup>
+  <Accordion title="1. Monitoring" icon="eye">
+    Bluejay watches the configured metric continuously. The alert is armed but silent. No notification fires until a violation crosses the threshold inside the time window.
+  </Accordion>
+  <Accordion title="2. Triggered / Firing" icon="bell">
+    The metric crossed the threshold the required number of times within the window. The alert moves to firing, the configured notification goes out (Slack, email, or dashboard badge), and the alert badge appears on the relevant agent dashboard.
+  </Accordion>
+  <Accordion title="3. Resolved" icon="circle-check">
+    The metric returns to normal and no longer satisfies the firing condition. Bluejay records the resolution time so you have a full timeline of the incident.
+  </Accordion>
+</AccordionGroup>
+
+## How to Think About Alerts
+
+Bluejay's observability surface has three complementary tools. Use each for what it does best.
+
+<AccordionGroup>
+  <Accordion title="Dashboards explore trends" icon="chart-line">
+    Dashboards help you understand patterns over hours, days, and weeks. Useful for slow-moving questions like "is quality drifting" or "is volume growing".
+  </Accordion>
+  <Accordion title="Logs inspect individual calls" icon="list">
+    Logs give you the per-call view. Useful for debugging a specific failure, replaying a transcript, or auditing what an agent did.
+  </Accordion>
+  <Accordion title="Alerts tell you to pay attention now" icon="bell">
+    Alerts cut through the noise to signal when production behavior actually demands attention. Useful for keeping the on-call team focused on what changed.
+  </Accordion>
+</AccordionGroup>
 
 ## Key Capabilities
 
-- **Threshold-based triggers** -- fire alerts when a metric crosses a boundary a configured number of times within a time window
-- **Configurable sensitivity** -- tune the number of occurrences and the time window to match the severity of each metric
-- **Channel routing** -- send alerts to specific Slack channels so the right team gets the right signal
-- **Dashboard integration** -- alert badges appear on agent dashboards for at-a-glance health monitoring
-- **Works for both observability and simulations** -- monitor production calls and test runs with the same alert model
+- **Threshold-based triggers.** Fire alerts when a metric crosses a boundary a configured number of times within a time window.
+- **Configurable sensitivity.** Tune the number of occurrences and the time window to match the severity of each metric.
+- **Channel routing.** Send alerts to specific Slack channels so the right team gets the right signal.
+- **Dashboard integration.** Alert badges appear on agent dashboards for at-a-glance health monitoring.
+- **Works for both observability and simulations.** Monitor production calls and test runs with the same alert model.
 
 ## Common Use Cases
 
-- Alert engineering when average latency exceeds 3 seconds across 5 calls in 10 minutes
-- Notify the support team the moment any production call is flagged for hallucination (occurrences set to 1)
-- Alert QA when simulation goal completion drops below 85% across 3 conversations in a run
-- Route compliance violations to a dedicated Slack channel with zero-tolerance thresholds
+- Alert engineering when average latency exceeds 3 seconds across 5 calls in 10 minutes.
+- Notify the support team the moment any production call is flagged for hallucination (occurrences set to 1).
+- Alert QA when simulation goal completion drops below 85% across 3 conversations in a run.
+- Route compliance violations to a dedicated Slack channel with zero-tolerance thresholds.
+- For a booking agent, alert on a sudden rise in failed-call rate, a drop in call volume, an increase in average latency, or an abnormal change in conversation quality.
 
-## Next Steps
+## Resources
 
 <CardGroup cols={2}>
   <Card title="Observability Alerts" icon="eye" href="/monitor/observability/alerts">
@@ -74,5 +154,11 @@ For critical metrics like hallucination detection, set occurrences to 1 so the a
   </Card>
   <Card title="Custom Metrics" icon="gauge-high" href="/key-concepts/custom-metrics/overview">
     Define the metrics that power your alert thresholds.
+  </Card>
+  <Card title="Monitor Alerts in Bluejay" icon="up-right-from-square" href="https://app.getbluejay.ai/monitor/alerts">
+    Open the live Alerts list in your Bluejay workspace.
+  </Card>
+  <Card title="Monitor Dashboards in Bluejay" icon="table-columns" href="https://app.getbluejay.ai/monitor/dashboards">
+    Open Observability dashboards in your Bluejay workspace.
   </Card>
 </CardGroup>

--- a/key-concepts/communities/overview.mdx
+++ b/key-concepts/communities/overview.mdx
@@ -4,7 +4,7 @@ description: Understand how Communities are organized and used in Bluejay
 icon: people-group
 ---
 
-A Community is a **test suite for your agent**. Just like a software test suite bundles individual test cases to verify that your code works correctly, a Community bundles Digital Humans — each representing a distinct user scenario — to verify that your agent handles real-world conversations correctly.
+A Community is a **test suite for your agent**. Just like a software test suite bundles individual test cases to verify that your code works correctly, a Community bundles Digital Humans (each representing a distinct user scenario) to verify that your agent handles real-world conversations correctly.
 
 ## What You'll Learn
 
@@ -14,7 +14,7 @@ A Community is a **test suite for your agent**. Just like a software test suite 
 
 ## Think of Communities as Test Suites
 
-In traditional software testing, you don't write one test and call it done. You accumulate test cases over time — covering happy paths, edge cases, regressions, and failure modes — until your test suite gives you confidence that your code is production-ready.
+In traditional software testing, you don't write one test and call it done. You accumulate test cases over time, covering happy paths, edge cases, regressions, and failure modes, until your test suite gives you confidence that your code is production-ready.
 
 Communities work the same way for AI agents. Each Digital Human in a Community is like an individual test case: it carries a specific scenario, persona traits, and success criteria. The Community as a whole is the test suite that exercises your agent across the full range of situations it needs to handle.
 
@@ -35,22 +35,22 @@ flowchart TD
 
 ## Building a Community Over Time
 
-The most effective Communities are not built all at once — they grow as your agent matures:
+The most effective Communities grow as your agent matures, rather than being built all at once:
 
-1. **Start with the basics.** Create Digital Humans for the core scenarios your agent must handle — the happy paths and most common requests.
+1. **Start with the basics.** Create Digital Humans for the core scenarios your agent must handle, such as the happy paths and most common requests.
 2. **Add edge cases.** As you discover gaps in your agent's performance (through production monitoring, observability, or manual testing), create new Digital Humans that target those specific weaknesses.
-3. **Lock in regressions.** When your agent fails on a real conversation, turn that failure into a Digital Human so it never slips through again — just like adding a regression test in code.
+3. **Lock in regressions.** When your agent fails on a real conversation, turn that failure into a Digital Human so it never slips through again, just like adding a regression test in code.
 4. **Expand coverage.** Over time, layer in Digital Humans for different languages, customer segments, emotional states, and scenario types until your Community comprehensively tests every capability your agent claims to support.
 
 The goal is to reach the point where running your Community gives you genuine confidence that a new agent version is ready for production.
 
 ## Key Capabilities
 
-- **Reusable test suites** -- define a Community once, run it against any agent or agent version
-- **Cross-agent comparison** -- use the same Community to benchmark different agents side-by-side under identical conditions
-- **Incremental growth** -- add new Digital Humans to a Community at any time as your testing needs evolve
-- **Flexible organization** -- group by audience segment, language, scenario type, or any criteria you define
-- **Batch simulation runs** -- run every Digital Human in a Community in a single batch operation
+- **Reusable test suites.** Define a Community once and run it against any agent or agent version.
+- **Cross-agent comparison.** Use the same Community to benchmark different agents side-by-side under identical conditions.
+- **Incremental growth.** Add new Digital Humans to a Community at any time as your testing needs evolve.
+- **Flexible organization.** Group by audience segment, language, scenario type, or any criteria you define.
+- **Batch simulation runs.** Run every Digital Human in a Community in a single batch operation.
 
 ## Common Use Cases
 

--- a/key-concepts/customer-traits/overview.mdx
+++ b/key-concepts/customer-traits/overview.mdx
@@ -28,10 +28,10 @@ Traits are the building blocks of realistic customer behavior. They define how a
 
 ## Key Capabilities
 
-- **Behavioral encoding** -- define tone, urgency, patience, and communication style
-- **Language and demographic signals** -- specify language preferences, technical proficiency, and contextual background
-- **Scenario-aware generation** -- traits adapt based on the simulation scenario context
-- **Full Customization** -- create any trait with any data type: Numbers, Strings, Dates, and more.
+- **Behavioral encoding.** Define tone, urgency, patience, and communication style.
+- **Language and demographic signals.** Specify language preferences, technical proficiency, and contextual background.
+- **Scenario-aware generation.** Traits adapt based on the simulation scenario context.
+- **Full customization.** Create any trait with any data type: Numbers, Strings, Dates, and more.
 
 ## Common Use Cases
 

--- a/key-concepts/dashboards/overview.mdx
+++ b/key-concepts/dashboards/overview.mdx
@@ -4,7 +4,7 @@ description: Understand how Dashboards are used in Bluejay
 icon: table-columns
 ---
 
-Bluejay provides two separate dashboard surfaces — one for **observability** and one for **simulations**. Each tracks a distinct stage of your agent's lifecycle, and the data between them is kept separate so you always have a clear picture of what is happening in production versus what happened during testing.
+Bluejay provides two separate dashboard surfaces: one for **observability** and one for **simulations**. Each tracks a distinct stage of your agent's lifecycle, and the data between them is kept separate so you always have a clear picture of what is happening in production versus what happened during testing.
 
 ## What You'll Learn
 
@@ -20,9 +20,9 @@ Observability dashboards let you monitor your agent's production performance and
 
 **Common use cases:**
 
-- **Customer sentiment analysis** — understand how customers feel about interactions and detect shifts in sentiment over time.
-- **A/B testing for agent releases** — compare metrics across feature variants to decide which changes to keep.
-- **Production pass-rate monitoring** — make sure key KPIs are maintained as your product grows and conversation volume scales.
+- **Customer sentiment analysis.** Understand how customers feel about interactions and detect shifts in sentiment over time.
+- **A/B testing for agent releases.** Compare metrics across feature variants to decide which changes to keep.
+- **Production pass-rate monitoring.** Make sure key KPIs are maintained as your product grows and conversation volume scales.
 
 **Standard practice:** build custom observability dashboards that cover the key performance areas for your agent in production, alongside a set of customer-behavior metrics that matter to the business and leadership.
 
@@ -32,8 +32,8 @@ Simulation dashboards help you validate that agents meet a quality bar before th
 
 **Common use cases:**
 
-- **Pre-release quality gates** — confirm that an agent reaches the required quality threshold before a production release.
-- **New-feature verification** — validate that newly built functionality performs correctly across a range of test scenarios.
+- **Pre-release quality gates.** Confirm that an agent reaches the required quality threshold before a production release.
+- **New-feature verification.** Validate that newly built functionality performs correctly across a range of test scenarios.
 
 **Standard practice:** create a dedicated dashboard for each new feature or category you add to your agent. This gives you a focused view of that feature's functionality during testing and a clear record of its readiness over time.
 


### PR DESCRIPTION
## Summary
Rewrite the Alerts overview to be developer-friendly and interactive, plus a small em-dash style pass across four sibling docs.

**Alerts overview rewrite (bulk of the diff):**
- Four interactive AccordionGroups (What Alerts Help You Catch, Anatomy of an Alert, Alert Lifecycle, How to Think About Alerts)
- Threshold example and critical-metric guidance wrapped in a Tip callout
- Renamed Next Steps to Resources and added deep links to the live Monitor Alerts and Monitor Dashboards screens
- Em-dashes and double-hyphen pseudo-dashes removed from prose

**Em-dash cleanup on sibling docs (style-only, no content changes):**
- `key-concepts/customer-traits/overview.mdx`
- `key-concepts/communities/overview.mdx`
- `core-concepts/communities.mdx`
- `key-concepts/dashboards/overview.mdx`

Mermaid edge syntax in Customer Traits is intentional grammar (not em-dashes) and was left intact.

## Test plan
- [ ] Alerts overview renders all four AccordionGroups
- [ ] Tip callout displays above Alert Lifecycle
- [ ] No em-dashes remain in prose across all five files
- [ ] Resources cards resolve, including the external Monitor links