### PR TITLE
docs(workflows): add Workflows vs Scenario Builder comparison section

### DIFF
--- a/key-concepts/agents/workflow.mdx
+++ b/key-concepts/agents/workflow.mdx
@@ -37,9 +37,24 @@ You pick how many digital humans to generate per path. Three discovered paths ×
     Full ElevenLabs agent definitions including sub-agent transfers, inline workflow nodes, and branches. See the ElevenLabs Simulations page for sync, push, the inline editor, and Generate From Workflow.
   </Card>
   <Card title="More coming soon" icon="rocket">
-    Workflow integration is built provider-by-provider. If your provider isn't listed yet, ping the Bluejay team and we'll add it.
+    Workflow integration is built provider-by-provider. If your provider isn't listed yet, ping the Bluejay team to request it.
   </Card>
 </CardGroup>
+
+## Workflows vs Scenario Builder
+
+Two Bluejay concepts can sound similar but do different jobs. Pick the right tool for what you're trying to change.
+
+<AccordionGroup>
+  <Accordion title="Workflows edit the agent itself" icon="diagram-project">
+    A **Workflow** is the agent's own provider-side definition, synced into Bluejay and rendered as an editable graph. When you change a node here, you are changing how the live agent behaves on real calls (once you push the edit back to the provider).
+  </Accordion>
+  <Accordion title="Scenario Builder edits the test paths" icon="map">
+    A **Scenario** is a test path that you run against an agent. Changing a scenario does not change how the live agent behaves. It only changes what the simulated caller does.
+  </Accordion>
+</AccordionGroup>
+
+Plain mapping: **Workflows = how the agent is configured. Scenario Builder = how a test runs against that agent.** If you came here looking to author test paths, head to the [Scenario Builder Overview](/key-concepts/scenario-builder/overview) instead.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
Add a "Workflows vs Scenario Builder" disambiguation section to the Workflows page. The comparison previously lived on the Scenario Builder Overview but belongs here so workflow-related disambiguation is anchored in one place. Single-file scope: `key-concepts/agents/workflow.mdx`.

**New section:** AccordionGroup with two entries (Workflows edit the agent itself, Scenario Builder edits the test paths) plus a one-line plain mapping and a link to the Scenario Builder Overview for readers who actually want to author test paths.

**Drive-by cleanup:** the page had a stray `we'll add it` in the "More coming soon" provider card. Rewrote to `to request it` so the page stays in external developer voice.

## Test plan
- [ ] The new AccordionGroup expands and collapses
- [ ] The link to the Scenario Builder Overview resolves
- [ ] No first-person Bluejay voice remains on the page
- [ ] No em-dashes in prose