### PR TITLE
docs(chirp): fix contradictory mark todo (barge-in vs stop)

### DIFF
--- a/chirp_rewrite.md
+++ b/chirp_rewrite.md
@@ -36,7 +36,7 @@ todos:
     content: Write the one-page customer-facing CHIRP spec doc emphasizing the zero-JSON minimum integration
     status: pending
   - id: mark-message
-    content: Add MessageType.MARK ("mark") + mark(name) builder + require_name() to chirp_message.py; on customer mark, echo the same name after audio_source.queued_duration drains; cancel pending echoes on barge-in/stop; mirror in tests/websocket_server.py. Playback-acknowledgment ack requested by RASA (replaces Twilio media-stream marks). Name-only; no streamSid/sequenceNumber/nesting.
+    content: Add MessageType.MARK ("mark") + mark(name) builder + require_name() to chirp_message.py; on customer mark, echo the same name after audio_source.queued_duration drains; cancel pending echoes on session stop only (barge-in does NOT cancel them — it interrupts the agent's outbound speech and never clears the customer-audio buffer marks are timed against); mirror in tests/websocket_server.py. Playback-acknowledgment ack requested by RASA (replaces Twilio media-stream marks). Name-only; no streamSid/sequenceNumber/nesting.
     status: pending
 isProject: false
 ---


### PR DESCRIPTION
## Problem
The `mark-message` todo in `chirp_rewrite.md` (merged via #235) reads "cancel pending echoes on **barge-in**/stop", which contradicts the spec body in the same file ("barge-in does not affect mark echoes ... pending echoes still complete normally") and the shipped code.

## Truth (per `livekit_agent/customer_integrations/translator.py`)
- `Translator.stop()` cancels pending mark-echo tasks.
- The barge-in handler (`_handle_customer_speech_started`) does **not** touch them. Barge-in interrupts the agent's outbound speech via the LiveKit interrupt path; it never clears the customer-audio `AudioSource` buffer the echoes are timed against.

## Fix
Reword the todo: cancel pending echoes on **session stop only**; barge-in does not cancel them. One-line change, aligns the todo with the body and the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the CHIRP spec: pending mark echoes are canceled on session stop only; barge-in does not cancel them. Resolves the contradiction in `chirp_rewrite.md` and aligns the doc with the current implementation in `translator.py`.

<sup>Written for commit 75aab23b177aeb1d6ea8a11941a7640f8fa4c153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

