### PR TITLE
Remove yes_no custom metric response type

### DIFF
--- a/api-reference/endpoint/create-custom-metric.mdx
+++ b/api-reference/endpoint/create-custom-metric.mdx
@@ -24,7 +24,7 @@ You are a senior backend engineer integrating the Bluejay API. Think step-by-ste
 | X-API-Key | string | API key required to authenticate requests. |
 | name | string | Name of the custom metric |
 | description | string | Description of what this metric measures |
-| response_type | string (enum: pass_fail, yes_no, qualitative, quantitative, json, enum) | Enum representing the possible response types for custom metrics. |
+| response_type | string (enum: pass_fail, qualitative, quantitative, json, enum) | Enum representing the possible response types for custom metrics. |
 
 Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpoint/create-custom-metric and include any optional parameters (e.g., `agent_id`, `agent_ids`, `min_value`, `max_value`, `category`, `tags`) that serve your integration's use case and align with Bluejay's testing and monitoring capabilities.
 

--- a/key-concepts/custom-metrics/metric-types.mdx
+++ b/key-concepts/custom-metrics/metric-types.mdx
@@ -113,27 +113,6 @@ To create this metric via API, use the [Create Custom Metric](/api-reference/end
 
 ---
 
-## Yes / No (Deprecated)
-
-**`response_type: yes_no`**
-
-<Warning>
-  Yes / No is deprecated. Use Pass / Fail instead. It is functionally identical and is the preferred type going forward.
-</Warning>
-
-Semantically identical to Pass / Fail, but the framing uses question-style prompts. Bluejay returns `yes` or `no`.
-
-```mermaid
-flowchart LR
-    A[Conversation] --> B{Question answered?}
-    B -->|True| C[yes]
-    B -->|False| D[no]
-```
-
-To create this metric via API, use the [Create Custom Metric](/api-reference/endpoint/create-custom-metric) endpoint with `response_type` set to `yes_no`. Optional fields such as `agent_id`, `category`, and `tags` match other metric types. See the full schema on that page.
-
----
-
 ## Quick Reference
 
 | Type | Returns | Best For | Status |
@@ -143,7 +122,6 @@ To create this metric via API, use the [Create Custom Metric](/api-reference/end
 | `qualitative` | Free-form text | Narrative feedback, coaching notes | Active |
 | `enum` | One of your defined labels | Classification, call outcomes | Active |
 | `json` | Structured JSON object | Multi-signal extraction in one pass | Active |
-| `yes_no` | `yes` or `no` | Question-style criteria | Deprecated |
 
 ---
 

--- a/key-concepts/metrics-lab/overview.mdx
+++ b/key-concepts/metrics-lab/overview.mdx
@@ -100,7 +100,7 @@ Click any row to open the detail panel. From here your reviewer records the grou
 
 The human input matches the metric's response type:
 
-- **Pass / Fail** and **Yes / No** metrics use simple buttons.
+- **Pass / Fail** metrics use simple buttons.
 - **Quantitative** metrics take a numeric score within the metric's range.
 - **Enum** metrics use a dropdown of your defined options.
 - **Qualitative** and **JSON** metrics take free text.

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -268,7 +268,7 @@ Get from account creation to running Simulations, evaluating production calls, a
         print(f"Metric created: {metric['id']}")
         ```
 
-        Learn more in the [Custom Metrics overview](/key-concepts/custom-metrics/overview). See the [Create Custom Metric API reference](/api-reference/endpoint/create-custom-metric) for all response types (`pass_fail`, `yes_no`, `qualitative`, `quantitative`, `json`, `enum`).
+        Learn more in the [Custom Metrics overview](/key-concepts/custom-metrics/overview). See the [Create Custom Metric API reference](/api-reference/endpoint/create-custom-metric) for all response types (`pass_fail`, `qualitative`, `quantitative`, `json`, `enum`).
       </Step>
 
       <Step title="Hook Up Observability">

--- a/university/observability/metrics-dashboards-alerts.mdx
+++ b/university/observability/metrics-dashboards-alerts.mdx
@@ -39,8 +39,7 @@ Video coming soon. Follow the written walkthrough below in the meantime.
 
     | Response type | What it returns | Example use case |
     |---|---|---|
-    | **Pass / Fail** | Binary yes/no result | "Did the agent read the required disclaimer?" |
-    | **Yes / No** | Binary with different labeling | "Did the caller express frustration?" |
+    | **Pass / Fail** | Binary pass/fail result | "Did the agent read the required disclaimer?" |
     | **Qualitative** | Rating scale (poor / fair / good / excellent) | "Overall conversation quality" |
     | **Quantitative** | Numeric value | "Number of times the agent interrupted" |
     | **JSON** | Structured data | "Extract the order details mentioned" |


### PR DESCRIPTION
## Summary
`yes_no` is being removed from the platform (existing metrics migrate to `enum`). Docs updated to match. Part of a 4-PR change (docs, middleware #888, frontend #948, evals).

## Changes
- `metric-types.mdx`: deleted the Yes/No section and its Quick Reference row.
- `create-custom-metric.mdx`: removed `yes_no` from the `response_type` enum.
- `quickstart.mdx`: removed `yes_no` from the response-type list.
- `metrics-dashboards-alerts.mdx`: removed the Yes/No table row.
- `metrics-lab/overview.mdx`: removed the Yes/No mention.