### PR TITLE
docs(dfcx): interactive rewrite of Dialogflow CX integration

### DIFF
--- a/integrations/google-dfcx.mdx
+++ b/integrations/google-dfcx.mdx
@@ -5,11 +5,40 @@ icon: 'google'
 ---
 
 Bluejay connects directly to your **Google Dialogflow CX (DFCX)** agents so you can test them
-with digital humans, visualize and edit their workflow, and — using the same APIs as the DFCX
-console — **snapshot versions and promote them to your environments**.
+with digital humans, visualize and edit their workflow, and, using the same APIs as the DFCX
+console, **snapshot versions and promote them to your environments**.
 
 The integration is **org-level**: you grant Bluejay access to your Google Cloud project once,
 sync your agents, and every DFCX agent in the project becomes available to test.
+
+## What You'll Learn
+
+- What the DFCX integration lets Bluejay do end-to-end
+- How to grant Bluejay a scoped service-account credential
+- How to sync, connect, test, edit, version, and promote your DFCX agents from Bluejay
+
+## How the Integration Works
+
+<AccordionGroup>
+  <Accordion title="Grant access" icon="key">
+    Paste a Google service-account key into Bluejay once. The credential is org-level and covers every DFCX (and CES) agent in the linked Google Cloud project.
+  </Accordion>
+  <Accordion title="Sync your agents" icon="rotate">
+    Bluejay scans your project across all Dialogflow locations and creates an agent in Bluejay for every DFCX (and CES) agent it finds.
+  </Accordion>
+  <Accordion title="Connect an agent" icon="plug">
+    Point Bluejay at the agent's `projects/.../agents/...` resource path and pick a **Voice** or **Chat** connection type.
+  </Accordion>
+  <Accordion title="Test with digital humans" icon="flask">
+    Run **Generate From Workflow** to enumerate flows, intents, event handlers, and playbook goals, then let digital humans drive each path end-to-end.
+  </Accordion>
+  <Accordion title="Edit the workflow" icon="pen-to-square">
+    Pull the agent onto Bluejay's canvas, edit nodes and routes visually, and push edits back to the DFCX draft with a diff preview.
+  </Accordion>
+  <Accordion title="Version and promote" icon="rocket">
+    Snapshot flows and playbooks into real DFCX versions on push, then deploy those versions into your DFCX environments.
+  </Accordion>
+</AccordionGroup>
 
 ### Prerequisites
 
@@ -17,7 +46,7 @@ sync your agents, and every DFCX agent in the project becomes available to test.
 - At least one **Dialogflow CX agent** in that project.
 - Permission to grant a service identity access to the project (to complete the steps below).
 
-Enable the Dialogflow API from **APIs & Services → Library → Dialogflow API** — it should read **API Enabled**:
+Enable the Dialogflow API from **APIs & Services → Library → Dialogflow API**. It should read **API Enabled**:
 
 ![Dialogflow API enabled in the Google Cloud console](/images/google-dfcx-enable-api.png)
 
@@ -31,88 +60,89 @@ both Google agent types are picked up by a single connection.
 ## 1. Grant Bluejay access (service account)
 
 Bluejay authenticates to your Google Cloud project with a **service-account key** that you create
-and paste into Bluejay. The key is encrypted at rest and scoped to Dialogflow only — it lets
-Bluejay talk to your agents, nothing else.
+and paste into Bluejay. The key is encrypted at rest and scoped to Dialogflow only, so it lets
+Bluejay talk to your agents and nothing else.
 
-### Step 1 — Create a service account with the right permissions
+### Step 1. Create a service account with the right permissions
 
 In the [Google Cloud Console → IAM & Admin → Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts):
 
-1. **Create Service Account** → give it a name (e.g. `bluejay-dfcx`).
+1. **Create Service Account**, then give it a name (e.g. `bluejay-dfcx`).
 
 ![Create the service account](/images/google-dfcx-create-sa.png)
 
 2. Decide which capability tier you need, then create a **custom IAM role** (IAM & Admin → Roles →
    **Create Role**) containing exactly those permissions and grant it to the service account. GCP
-   grants *roles*, not bare permissions — the custom role is how you apply a minimal set. Each tier
+   grants *roles*, not bare permissions, so a custom role is how you apply a minimal set. Each tier
    also lists a predefined-role equivalent if you prefer a quicker (but broader) grant.
 
-#### Tier 1 — Test only (read + run simulations)
+<AccordionGroup>
+  <Accordion title="Tier 1: Test only (read + run simulations)" icon="eye">
+    Use this tier if Bluejay only needs to sync agent definitions and run live simulations.
 
-Use this tier if Bluejay only needs to sync agent definitions and run live simulations.
+    **Read / sync permissions**
 
-**Read / sync permissions**
+    | Permission | Purpose |
+    | --- | --- |
+    | `dialogflow.agents.get`, `dialogflow.agents.list` | Discover agents in your project |
+    | `dialogflow.flows.get`, `dialogflow.flows.list` | Read flow definitions |
+    | `dialogflow.pages.get`, `dialogflow.pages.list` | Read pages within flows |
+    | `dialogflow.intents.get`, `dialogflow.intents.list` | Read intent definitions |
+    | `dialogflow.transitionRouteGroups.get`, `dialogflow.transitionRouteGroups.list` | Read route groups |
+    | `dialogflow.playbooks.get`, `dialogflow.playbooks.list` | Read playbook definitions |
+    | `dialogflow.tools.get`, `dialogflow.tools.list` | Read tool definitions |
+    | `dialogflow.generators.get`, `dialogflow.generators.list` | Read generator definitions |
 
-| Permission | Purpose |
-| --- | --- |
-| `dialogflow.agents.get`, `dialogflow.agents.list` | Discover agents in your project |
-| `dialogflow.flows.get`, `dialogflow.flows.list` | Read flow definitions |
-| `dialogflow.pages.get`, `dialogflow.pages.list` | Read pages within flows |
-| `dialogflow.intents.get`, `dialogflow.intents.list` | Read intent definitions |
-| `dialogflow.transitionRouteGroups.get`, `dialogflow.transitionRouteGroups.list` | Read route groups |
-| `dialogflow.playbooks.get`, `dialogflow.playbooks.list` | Read playbook definitions |
-| `dialogflow.tools.get`, `dialogflow.tools.list` | Read tool definitions |
-| `dialogflow.generators.get`, `dialogflow.generators.list` | Read generator definitions |
+    **Runtime permissions**
 
-**Runtime permissions**
+    | Permission | Purpose |
+    | --- | --- |
+    | `dialogflow.sessions.detectIntent` | Send turns to the agent during a simulation |
+    | `serviceusage.services.use` | Authorize the quota project header Bluejay sends with every API call |
 
-| Permission | Purpose |
-| --- | --- |
-| `dialogflow.sessions.detectIntent` | Send turns to the agent during a simulation |
-| `serviceusage.services.use` | Authorize the quota project header Bluejay sends with every API call |
+    <Warning>
+    `serviceusage.services.use` is the single most-missed permission. Without it, live simulations
+    fail immediately with `USER_PROJECT_DENIED`. This happens because the Dialogflow runtime checks a
+    Service Usage quota when Bluejay sends an `x-goog-user-project` header on each request, so the
+    permission must be present even if billing is not your concern.
+    </Warning>
 
-<Warning>
-`serviceusage.services.use` is the single most-missed permission. Without it, live simulations
-fail immediately with `USER_PROJECT_DENIED`. This happens because the Dialogflow runtime checks a
-Service Usage quota when Bluejay sends an `x-goog-user-project` header on each request — the
-permission must be present even if billing is not your concern.
-</Warning>
+    **Predefined-role equivalent (quicker, broader):** `roles/dialogflow.reader` +
+    `roles/dialogflow.client`. This grants everything in Tier 1 and a bit more.
+  </Accordion>
+  <Accordion title="Tier 2: Edit + push (also version & promote workflows)" icon="pen-to-square">
+    Use this tier if Bluejay also needs to push workflow edits, snapshot versions, and deploy to
+    environments. Tier 2 includes all Tier 1 permissions plus the following writes:
 
-**Predefined-role equivalent (quicker, broader):** `roles/dialogflow.reader` +
-`roles/dialogflow.client` — grants everything in Tier 1 and a bit more.
+    | Permission | Purpose |
+    | --- | --- |
+    | `dialogflow.flows.update` | Push flow edits |
+    | `dialogflow.pages.create`, `dialogflow.pages.update`, `dialogflow.pages.delete` | Create, edit, and remove pages |
+    | `dialogflow.intents.create`, `dialogflow.intents.update`, `dialogflow.intents.delete` | Create, edit, and remove intents |
+    | `dialogflow.transitionRouteGroups.create`, `dialogflow.transitionRouteGroups.update`, `dialogflow.transitionRouteGroups.delete` | Create, edit, and remove route groups |
+    | `dialogflow.playbooks.update` | Push playbook edits |
+    | `dialogflow.tools.create`, `dialogflow.tools.update`, `dialogflow.tools.delete` | Create, edit, and remove tools |
+    | `dialogflow.versions.create` | Snapshot a version on push |
+    | `dialogflow.environments.update` | Promote flow versions to an environment (the `deployFlow` API authorizes on `dialogflow.environments.update`) |
 
-#### Tier 2 — Edit + push (also version & promote workflows)
-
-Use this tier if Bluejay also needs to push workflow edits, snapshot versions, and deploy to
-environments. Tier 2 includes all Tier 1 permissions plus the following writes:
-
-| Permission | Purpose |
-| --- | --- |
-| `dialogflow.flows.update` | Push flow edits |
-| `dialogflow.pages.create`, `dialogflow.pages.update`, `dialogflow.pages.delete` | Create, edit, and remove pages |
-| `dialogflow.intents.create`, `dialogflow.intents.update`, `dialogflow.intents.delete` | Create, edit, and remove intents |
-| `dialogflow.transitionRouteGroups.create`, `dialogflow.transitionRouteGroups.update`, `dialogflow.transitionRouteGroups.delete` | Create, edit, and remove route groups |
-| `dialogflow.playbooks.update` | Push playbook edits |
-| `dialogflow.tools.create`, `dialogflow.tools.update`, `dialogflow.tools.delete` | Create, edit, and remove tools |
-| `dialogflow.versions.create` | Snapshot a version on push |
-| `dialogflow.environments.update` | Promote flow versions to an environment (the `deployFlow` API authorizes on `dialogflow.environments.update`) |
-
-**Predefined-role equivalent (quicker, broader):** `roles/dialogflow.admin` — grants the full
-Dialogflow feature set.
+    **Predefined-role equivalent (quicker, broader):** `roles/dialogflow.admin`. This grants the full
+    Dialogflow feature set.
+  </Accordion>
+</AccordionGroup>
 
 ![Grant the custom role to the service account](/images/google-dfcx-sa-role.png)
 
-### Step 2 — Create a JSON key
+### Step 2. Create a JSON key
 
 On that service account, open the **Keys** tab → **Add Key → Create new key → JSON** → **Create**.
 A `.json` key file downloads to your machine.
 
 <Warning>
-Treat the key file like a password — it grants the role above on your project until you rotate or
+Treat the key file like a password. It grants the role above on your project until you rotate or
 delete it. You can revoke it anytime from the same **Keys** tab.
 </Warning>
 
-### Step 3 — Add it to Bluejay
+### Step 3. Add it to Bluejay
 
 1. Log into your **Bluejay Dashboard**.
 2. Click your **Organization** menu (bottom-left) → **Integrations** → **Google Agents**.
@@ -133,8 +163,8 @@ Once the credential is saved, discover your agents:
 2. Bluejay scans your project across all Dialogflow locations and creates an agent in Bluejay for
    every DFCX (and CES) agent it finds.
 
-The sync result reports how many agents were **created**, **updated**, or **removed** (an agent
-deleted in Google is flagged in Bluejay rather than dropped). Re-run Sync any time you add agents
+The sync result reports how many agents were **created**, **updated**, or **removed**. An agent
+deleted in Google is flagged in Bluejay rather than dropped. Re-run Sync any time you add agents
 in Google.
 
 ---
@@ -144,36 +174,45 @@ in Google.
 Most agents are wired up automatically by Sync. To connect or adjust one manually:
 
 1. Open the agent's **Connection** settings.
-2. Choose the **Google Dialogflow CX** connection type — **Voice** or **Chat**.
+2. Choose the **Google Dialogflow CX** connection type, then pick **Voice** or **Chat**.
 3. Paste the agent's resource path. You can paste either the full DFCX console URL or the path
-   directly — Bluejay normalizes it to:
+   directly, and Bluejay normalizes it to:
 
    ```
    projects/{PROJECT_ID}/locations/{LOCATION}/agents/{AGENT_ID}
    ```
 
-That's all that's needed — the org-level credential from Step 1 handles authentication.
+That's all that's needed. The org-level credential from Step 1 handles authentication.
 
 ---
 
 ## 4. Test your agent
 
 With an agent connected you can run simulations against it like any other Bluejay agent. In
-**Simulations → Create Simulation**, pick a simulation type — **Generate From Workflow** is the one
+**Simulations → Create Simulation**, pick a simulation type. **Generate From Workflow** is the one
 that reads your DFCX agent directly:
 
-![Create Simulation — pick a type](/images/google-dfcx-sim-types.png)
+![Create Simulation, pick a type](/images/google-dfcx-sim-types.png)
 
-- **Voice** simulations bridge audio between a Bluejay digital human (the caller) and your DFCX
-  agent in real time.
-- **Chat** simulations drive a turn-by-turn text conversation.
-
-**Generate From Workflow** reads your synced agent and proposes test cases drawn from *all* of its
-authored logic — flow intents and event handlers, and each playbook's goal, instruction steps,
-tool calls, and handoffs. Multi-step handoffs are composed into **end-to-end journeys** (for
-example, *Default Start Flow → Billing Disputes Flow → Billing Specialist Playbook*), so you can
-test realistic paths, not just isolated steps. Pick how many digital humans to generate per
-scenario and hit **Generate**.
+<AccordionGroup>
+  <Accordion title="Voice simulations" icon="phone">
+    Bridge audio between a Bluejay digital human (the caller) and your DFCX agent in real time.
+    Everything the caller says is transcribed for the agent, and every agent response is synthesized
+    back to the caller.
+  </Accordion>
+  <Accordion title="Chat simulations" icon="message">
+    Drive a turn-by-turn text conversation. Useful when you want deterministic replays or want to
+    focus on flow logic without audio in the loop.
+  </Accordion>
+  <Accordion title="Generate From Workflow" icon="wand-magic-sparkles">
+    Reads your synced agent and proposes test cases drawn from *all* of its authored logic: flow
+    intents and event handlers, and each playbook's goal, instruction steps, tool calls, and
+    handoffs. Multi-step handoffs are composed into **end-to-end journeys** (for example, *Default
+    Start Flow → Billing Disputes Flow → Billing Specialist Playbook*), so you can test realistic
+    paths across your agent, not just isolated steps. Pick how many digital humans to generate per
+    scenario and hit **Generate**.
+  </Accordion>
+</AccordionGroup>
 
 ![Test cases generated from your workflow](/images/google-dfcx-generate.png)
 
@@ -184,11 +223,20 @@ scenario and hit **Generate**.
 Open the agent's **Workflow** tab to see its flows, pages, routes, event handlers, and playbooks on
 an interactive canvas.
 
-- **Pull** refreshes Bluejay's copy from the live DFCX agent.
-- Edit nodes, routes, and handlers directly on the canvas.
-- **Push to DFCX** sends your local edits back to the agent's **draft**. A diff preview shows
-  exactly what will change, and conflicts are surfaced if the agent drifted on Google's side since
-  your last sync.
+<AccordionGroup>
+  <Accordion title="Pull" icon="arrow-down-to-line">
+    Refresh Bluejay's copy from the live DFCX agent. Use this before editing so you start from the
+    current draft rather than a stale snapshot.
+  </Accordion>
+  <Accordion title="Edit on the canvas" icon="pen-ruler">
+    Edit nodes, routes, and handlers directly on the canvas. Changes stay local in Bluejay until
+    you push them back.
+  </Accordion>
+  <Accordion title="Push to DFCX" icon="arrow-up-from-line">
+    Send your local edits back to the agent's **draft**. A diff preview shows exactly what will
+    change, and conflicts are surfaced if the agent drifted on Google's side since your last sync.
+  </Accordion>
+</AccordionGroup>
 
 ![The DFCX workflow canvas in Bluejay](/images/google-dfcx-workflow-canvas.png)
 
@@ -196,32 +244,33 @@ an interactive canvas.
 
 ## 6. Versioning & promotion
 
-Bluejay is a thin, governed front door to DFCX's own versioning and environments — a version or
+Bluejay is a thin, governed front door to DFCX's own versioning and environments. A version or
 deployment you make here is a **real DFCX version/deployment** and shows up in the DFCX console.
 
-### Version on push
+<AccordionGroup>
+  <Accordion title="Version on push" icon="camera">
+    When pushing, enable **Version on push** to snapshot the flows and playbooks your push changed
+    into new immutable DFCX versions, automatically, and only for what actually changed. The result
+    tells you which versions were created.
 
-When pushing, enable **Version on push** to snapshot the flows and playbooks your push changed into
-new immutable DFCX versions — automatically, and only for what actually changed. The result tells
-you which versions were created.
+    <Note>
+    Snapshotting is safe: versions are immutable copies in your draft project. DFCX caps the number
+    of versions per flow, so versioning is opt-in per push rather than automatic on every save.
+    </Note>
+  </Accordion>
+  <Accordion title="Promote to an environment" icon="rocket">
+    Use **Promote** to deploy flow versions into one of your DFCX **environments** (e.g. Staging,
+    Production):
 
-<Note>
-Snapshotting is safe: versions are immutable copies in your draft project. DFCX caps the number of
-versions per flow, so versioning is opt-in per push rather than automatic on every save.
-</Note>
+    1. Click **Promote** on the workflow.
+    2. Choose the **target environment**.
+    3. For each flow, pick the **version** to deploy (or leave it unchanged).
+    4. Confirm.
 
-### Promote to an environment
-
-Use **Promote** to deploy flow versions into one of your DFCX **environments** (e.g. Staging,
-Production):
-
-1. Click **Promote** on the workflow.
-2. Choose the **target environment**.
-3. For each flow, pick the **version** to deploy (or leave it unchanged).
-4. Confirm.
-
-This calls the same `deployFlow` operation as the DFCX console — the environment immediately serves
-the deployed versions, and the deployment appears in your DFCX deployment history.
+    This calls the same `deployFlow` operation as the DFCX console. The environment immediately
+    serves the deployed versions, and the deployment appears in your DFCX deployment history.
+  </Accordion>
+</AccordionGroup>
 
 ---
 
@@ -235,3 +284,20 @@ the deployed versions, and the deployment appears in your DFCX deployment histor
 | Test | Simulations | Generate digital humans from the workflow and run them |
 | Edit | Agent → Workflow | Pull, edit on canvas, Push to DFCX (with diff + conflict checks) |
 | Version & promote | Agent → Workflow | Version-on-push; Promote flow versions to an environment |
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="Conversational Engine (CES)" icon="google" href="/integrations/google-ces">
+    Set up the companion CES connection covered by the same service-account key.
+  </Card>
+  <Card title="Simulations Overview" icon="flask-vial" href="/test/simulations/overview">
+    See how Generate From Workflow fits into the broader simulation lifecycle.
+  </Card>
+  <Card title="Digital Humans" icon="users" href="/key-concepts/digital-humans/overview">
+    Learn how the personas driving your DFCX simulations are configured.
+  </Card>
+  <Card title="Workflows" icon="diagram-project" href="/key-concepts/agents/workflow">
+    Understand how workflows are modeled in Bluejay across every supported provider.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Strip em-dashes throughout `integrations/google-dfcx.mdx` (23 removed)
- Add **What You'll Learn** and **How the Integration Works** AccordionGroups at the top so readers can browse the six-phase flow before diving in
- Wrap Tier 1 / Tier 2 permission sets in an AccordionGroup (each accordion retains its full permission table + predefined-role equivalent)
- Break the Test section into three Accordions: Voice, Chat, and Generate From Workflow
- Wrap the workflow canvas actions (Pull, Edit on canvas, Push to DFCX) in an AccordionGroup
- Split the Versioning & Promotion section into two Accordions (Version on push, Promote to an environment)
- Add a Resources CardGroup at the end linking to CES, Simulations Overview, Digital Humans, and Workflows

All existing images, warnings, notes, and the summary table are preserved.

## Test plan

- [x] Verified locally at http://localhost:3333/integrations/google-dfcx that every new section renders
- [x] `grep -c '—'` on the file returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)