### PR TITLE
docs(ces): interactive rewrite of Conversational Engine integration

### DIFF
--- a/integrations/google-ces.mdx
+++ b/integrations/google-ces.mdx
@@ -5,8 +5,31 @@ icon: 'google'
 ---
 
 Bluejay connects directly to your **Google Conversational Engine (CES)** agents so you can test them
-with digital humans over **Voice or Chat** — sync your agents, connect one, and run simulations
+with digital humans over **Voice or Chat**. Sync your agents, connect one, and run simulations
 against it.
+
+## What You'll Learn
+
+- What the CES integration lets Bluejay do end-to-end
+- How to grant Bluejay a scoped Google Cloud service-account credential (shared with Dialogflow CX)
+- How to sync, connect, and test your CES engines from Bluejay over Voice or Chat
+
+## How the Integration Works
+
+<AccordionGroup>
+  <Accordion title="Grant access" icon="key">
+    Paste a Google service-account key into Bluejay once. The same credential also covers Dialogflow CX, so a single key unlocks every Google agent in your project.
+  </Accordion>
+  <Accordion title="Sync your agents" icon="rotate">
+    Bluejay scans your Google Cloud project across every location and creates a Bluejay agent for every CES engine (and any DFCX agents) it finds.
+  </Accordion>
+  <Accordion title="Connect an agent" icon="plug">
+    Set the CES engine's **App / Engine ID** and **Deployment ID** on the agent, then choose **Voice** or **Chat** as the connection type.
+  </Accordion>
+  <Accordion title="Test with digital humans" icon="flask">
+    Author digital humans and run simulations against the connected CES agent over Voice or Chat. Client-side tool calls flow through automatically.
+  </Accordion>
+</AccordionGroup>
 
 ### Prerequisites
 
@@ -14,13 +37,13 @@ against it.
 - At least one **CES app** in that project.
 - Permission to grant a service identity access to the project (to complete the steps below).
 
-Enable the API from **APIs & Services → Library** — it should read **API Enabled**:
+Enable the API from **APIs & Services → Library**. It should read **API Enabled**:
 
 ![Conversational Engine API enabled in the Google Cloud console](/images/google-ces-enable-api.png)
 
 <Note>
 CES shares the **same "Google Agents" integration and the same service-account key** as
-[Dialogflow CX](/integrations/google-dfcx) — one credential covers both Google agent types. If you
+[Dialogflow CX](/integrations/google-dfcx), so one credential covers both Google agent types. If you
 have already set up the shared credential for DFCX, you only need the **CES-specific permissions**
 and the steps below. See the [Dialogflow CX page](/integrations/google-dfcx) for the shared
 credential setup.
@@ -34,47 +57,74 @@ Bluejay authenticates to your Google Cloud project with a **service-account key*
 and paste into Bluejay. The key is encrypted at rest and only ever used to call the Google APIs for
 your agents.
 
-### Step 1 — Create a service account with the right permissions
+### Step 1. Create a service account with the right permissions
 
 In the [Google Cloud Console → IAM & Admin → Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts):
 
-1. **Create Service Account** → give it a name (e.g. `bluejay-ces`).
+1. **Create Service Account**, then give it a name (e.g. `bluejay-ces`).
 
 ![Create the service account](/images/google-ces-create-sa.png)
 
-2. Grant the minimal CES permissions. CES is **read + run only** — there is no edit/push tier. CES
+2. Grant the minimal CES permissions. CES is **read + run only**, so there is no edit/push tier. CES
    apps live under the **Conversational Engine API** (`ces.googleapis.com`). Create a **custom IAM
    role** (IAM & Admin → Roles → **Create Role**) with exactly the permissions below, or use the
    pre-built role listed for each group.
 
-| Purpose | Permissions | Pre-built role |
-| --- | --- | --- |
-| **Discovery / sync** | `ces.apps.get`, `ces.apps.list`, `ces.deployments.get`, `ces.deployments.list` | `roles/ces.viewer` |
-| **Runtime (`runSession`)** | `ces.sessions.runSession`, `ces.sessions.bidiRunSession` | `roles/ces.client` |
-| **Runtime quota** (required) | `serviceusage.services.use` | `roles/serviceusage.serviceUsageConsumer` |
+<AccordionGroup>
+  <Accordion title="Discovery / sync permissions" icon="magnifying-glass">
+    Bluejay uses these permissions to list CES engines and their deployments during **Sync**.
 
-`roles/ces.viewer` and `roles/ces.client` are **complementary, not overlapping** — viewer has the
-app/deployment reads but no session permission; client has the session permissions but no reads. So
-the pre-built path is **`roles/ces.viewer` + `roles/ces.client` + `roles/serviceusage.serviceUsageConsumer`**,
-or **`roles/ces.admin`** (covers read + run) **+ `roles/serviceusage.serviceUsageConsumer`**.
+    | Permission | Purpose |
+    | --- | --- |
+    | `ces.apps.get`, `ces.apps.list` | Discover CES engines in your project |
+    | `ces.deployments.get`, `ces.deployments.list` | Read deployments for each engine |
+
+    **Pre-built role:** `roles/ces.viewer`
+  </Accordion>
+  <Accordion title="Runtime (`runSession`) permissions" icon="play">
+    Bluejay uses these permissions to drive turns during a live simulation.
+
+    | Permission | Purpose |
+    | --- | --- |
+    | `ces.sessions.runSession` | Send turns to the CES agent during a simulation |
+    | `ces.sessions.bidiRunSession` | Stream bidirectional audio during Voice simulations |
+
+    **Pre-built role:** `roles/ces.client`
+  </Accordion>
+  <Accordion title="Runtime quota permission (required)" icon="triangle-exclamation">
+    Required regardless of which capability path you pick.
+
+    | Permission | Purpose |
+    | --- | --- |
+    | `serviceusage.services.use` | Authorize the quota project header Bluejay sends with every API call |
+
+    **Pre-built role:** `roles/serviceusage.serviceUsageConsumer`
+  </Accordion>
+</AccordionGroup>
+
+`roles/ces.viewer` and `roles/ces.client` are **complementary**: viewer covers the app and
+deployment reads without granting session access, and client covers the session runtime without
+granting any reads. So the pre-built path is **`roles/ces.viewer` + `roles/ces.client` +
+`roles/serviceusage.serviceUsageConsumer`**, or **`roles/ces.admin`** (covers read + run) **+
+`roles/serviceusage.serviceUsageConsumer`**.
 
 <Warning>
-`serviceusage.services.use` is required regardless of which path you pick — without it, runtime
+`serviceusage.services.use` is required regardless of which path you pick. Without it, runtime
 calls fail immediately with `USER_PROJECT_DENIED` (Bluejay sends an `x-goog-user-project` quota
 header on every request).
 </Warning>
 
-### Step 2 — Create a JSON key
+### Step 2. Create a JSON key
 
 On that service account, open the **Keys** tab → **Add Key → Create new key → JSON** → **Create**.
 A `.json` key file downloads to your machine.
 
 <Warning>
-Treat the key file like a password — it grants the permissions above on your project until you
+Treat the key file like a password. It grants the permissions above on your project until you
 rotate or delete it. You can revoke it anytime from the same **Keys** tab.
 </Warning>
 
-### Step 3 — Add it to Bluejay
+### Step 3. Add it to Bluejay
 
 1. Log into your **Bluejay Dashboard**.
 2. Click your **Organization** menu (bottom-left) → **Integrations** → **Google Agents**.
@@ -83,7 +133,7 @@ rotate or delete it. You can revoke it anytime from the same **Keys** tab.
 
 ![Paste the service-account key in the Google Agents integration](/images/google-ces-integrations-tab.png)
 
-This is the **same credential** used for Dialogflow CX — a single key covers both Google agent
+This is the **same credential** used for Dialogflow CX, so a single key covers both Google agent
 types. The key is **encrypted at rest** and only ever used to call the Google APIs for your agents.
 
 ---
@@ -96,8 +146,8 @@ Once the credential is saved, discover your agents:
 2. Bluejay scans your project across all locations and creates an agent in Bluejay for every CES
    engine it finds (alongside any Dialogflow CX agents).
 
-The sync result reports how many agents were **created**, **updated**, or **removed** (an agent
-deleted in Google is flagged in Bluejay rather than dropped). Re-run Sync any time you add agents
+The sync result reports how many agents were **created**, **updated**, or **removed**. An agent
+deleted in Google is flagged in Bluejay rather than dropped. Re-run Sync any time you add agents
 in Google.
 
 ---
@@ -107,7 +157,7 @@ in Google.
 Most agents are wired up automatically by Sync. To connect or adjust one manually:
 
 1. Open the agent's **Connection** settings.
-2. Choose the **Google Conversational Engine (CES)** connection type — **Voice** or **Chat**.
+2. Choose the **Google Conversational Engine (CES)** connection type, then pick **Voice** or **Chat**.
 3. Set the CES connection fields:
 
 | Field | What it is |
@@ -115,7 +165,7 @@ Most agents are wired up automatically by Sync. To connect or adjust one manuall
 | **App / Engine ID** (`ces_app_id`) | The CES engine (app) identifier |
 | **Deployment ID** (`ces_deployment_id`) | The CES deployment to run against |
 
-That's all that's needed — the service-account key from Step 1 handles authentication.
+That's all that's needed. The service-account key from Step 1 handles authentication.
 
 ---
 
@@ -125,18 +175,26 @@ With an agent connected you can run simulations against it like any other Blueja
 **Simulations → Create Simulation**, pick a simulation type and run digital humans against your CES
 agent:
 
-![Create Simulation — pick a type](/images/google-dfcx-sim-types.png)
+![Create Simulation, pick a type](/images/google-dfcx-sim-types.png)
 
 CES supports **both Voice and Chat**, chosen by the agent's connection type:
 
-- **Voice** simulations bridge audio between a Bluejay digital human (the caller) and your CES agent
-  in real time.
-- **Chat** simulations drive a turn-by-turn text conversation.
+<AccordionGroup>
+  <Accordion title="Voice simulations" icon="phone">
+    Bridge audio between a Bluejay digital human (the caller) and your CES agent in real time.
+    Everything the caller says is transcribed for the agent, and every agent response is
+    synthesized back to the caller.
+  </Accordion>
+  <Accordion title="Chat simulations" icon="message">
+    Drive a turn-by-turn text conversation. Useful when you want deterministic replays or want to
+    focus on the flow logic without audio in the loop.
+  </Accordion>
+</AccordionGroup>
 
 <Note>
 **Tool calls are handled automatically.** When your CES agent invokes a tool or function call
 mid-conversation, Bluejay captures the invocation (tool name + arguments), returns a response so the
-turn keeps flowing, and sends that tool response back to CES — no setup required. Today the returned
+turn keeps flowing, and sends that tool response back to CES. No setup required. Today the returned
 value is a default acknowledgment (`{"status": "ok"}`); configurable/scripted tool responses are on
 the way. Server-side tools that CES runs itself (data stores, OpenAPI/connectors) still execute
 normally on Google's side; this only covers the client-side calls handed back to the caller.
@@ -154,3 +212,20 @@ Author your digital humans directly and run them against the connected agent.
 | Sync | Settings → Integrations → Google Agents | Discover all CES engines (and DFCX agents) in the project |
 | Connect | Agent → Connection | Set App/Engine ID + Deployment ID; pick Voice or Chat |
 | Test | Simulations | Run digital humans against the agent over Voice or Chat |
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="Dialogflow CX" icon="google" href="/integrations/google-dfcx">
+    Set up the companion DFCX connection covered by the same service-account key.
+  </Card>
+  <Card title="Simulations Overview" icon="flask-vial" href="/test/simulations/overview">
+    Understand how CES runs fit into the broader simulation lifecycle.
+  </Card>
+  <Card title="Digital Humans" icon="users" href="/key-concepts/digital-humans/overview">
+    Learn how the personas driving your CES simulations are configured.
+  </Card>
+  <Card title="Agents Overview" icon="robot" href="/key-concepts/agents/overview">
+    See how connected CES agents fit alongside other providers in Bluejay.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Strip em-dashes throughout `integrations/google-ces.mdx` (14 removed)
- Add **What You'll Learn** and **How the Integration Works** AccordionGroups at the top so readers can browse the four-phase flow before diving in
- Wrap the CES permission groups (**Discovery / Sync**, **Runtime `runSession`**, **Runtime quota**) in an AccordionGroup so each block has its own table plus pre-built role
- Split the Test section's **Voice** and **Chat** descriptions into Accordions; keep the automatic tool-calls Note in-line
- Add a Resources CardGroup at the end linking to Dialogflow CX, Simulations Overview, Digital Humans, and Agents Overview

All existing images, warnings, notes, and the summary table are preserved.

## Test plan

- [x] Verified locally at http://localhost:3333/integrations/google-ces that every new section renders
- [x] `grep -c '—'` on the file returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)