### PR TITLE
Teardown: conversation terminology in API reference

### DIFF
--- a/api-reference/endpoint/delete-call-log.mdx
+++ b/api-reference/endpoint/delete-call-log.mdx
@@ -54,4 +54,4 @@ Then implement the integration, export it, and confirm it compiles/passes lint.
 </div>
 
 
-This endpoint allows you to delete a call log and optionally the recording only.
+This endpoint allows you to delete a call log and optionally the recording only. The `call_id` identifies the observability conversation to delete.

--- a/api-reference/endpoint/retrieve-call-log.mdx
+++ b/api-reference/endpoint/retrieve-call-log.mdx
@@ -52,4 +52,4 @@ Then implement the integration, export it, and confirm it compiles/passes lint.
 </div>
 
 
-Retrieves the call log for a specific call identified by `call_id`. This endpoint returns detailed information about the call, including evaluations, hallucinations, redundancy, and custom evaluation metrics.
+Retrieves the call log for a specific observability conversation identified by `call_id`. This endpoint returns detailed information about the conversation, including evaluations, hallucinations, redundancy, and custom evaluation metrics.

--- a/api-reference/endpoint/retrieve-call-logs.mdx
+++ b/api-reference/endpoint/retrieve-call-logs.mdx
@@ -54,4 +54,4 @@ Then implement the integration, export it, and confirm it compiles/passes lint.
 </div>
 
 
-Retrieves the call logs for a specific agent identified by `agent_id`. This endpoint returns detailed information about each call, including evaluations, hallucinations, redundancy, and custom evaluation metrics.
+Retrieves the call logs for a specific agent identified by `agent_id`. This endpoint returns detailed information about each observability conversation, including evaluations, hallucinations, redundancy, and custom evaluation metrics.

--- a/api-reference/endpoint/retrieve-simulation-result.mdx
+++ b/api-reference/endpoint/retrieve-simulation-result.mdx
@@ -52,4 +52,4 @@ Then implement the integration, export it, and confirm it compiles/passes lint.
 </div>
 
 
-Retrieves a single simulation result and its associated custom metrics by `test_result_id`. 
+Retrieves a single simulation conversation and its associated custom metrics by `test_result_id`. The `test_result_id` identifies the simulation conversation. 

--- a/api-reference/endpoint/retrieve-simulation-results.mdx
+++ b/api-reference/endpoint/retrieve-simulation-results.mdx
@@ -52,4 +52,4 @@ Then implement the integration, export it, and confirm it compiles/passes lint.
 </div>
 
 
-Retrieves the simulation results for a specific agent simulation run by `simulation_run_id`. This endpoint returns detailed information about the simulation, including the agent's performance, evaluations, hallucinations, redundancy, and custom evaluation metrics.
+Retrieves the simulation conversations for a specific agent simulation run by `simulation_run_id`. This endpoint returns detailed information about each simulation conversation, including the agent's performance, evaluations, hallucinations, redundancy, and custom evaluation metrics.

--- a/api-reference/webhook/events-webhook.mdx
+++ b/api-reference/webhook/events-webhook.mdx
@@ -19,20 +19,20 @@ You are a senior backend engineer integrating the Bluejay API. Think step-by-ste
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | **Variant: `simulation_result_evaluated`** | | | |
-| id | integer | yes | The ID of the simulation result |
+| id | integer | yes | The ID of the simulation conversation (the value carried by `test_result_id` elsewhere in the API) |
 | digital_human_id | integer | yes | The ID of the digital human |
 | simulation_run_id | integer | yes | The ID of the simulation run that this simulation result belongs to |
 | simulation_id | integer | yes | The ID of the simulation that this simulation result belongs to |
 | agent_id | integer | yes | The ID of the agent that this simulation result belongs to |
 | **Variant: `observability_call_evaluated`** | | | |
-| id | string | yes | Unique identifier for the call |
-| agent_id | string | yes | ID of the agent associated with the call |
+| id | string | yes | Unique identifier for the observability conversation (the value carried by `call_id` elsewhere in the API) |
+| agent_id | string | yes | ID of the agent associated with the conversation |
 | recording_url | string (nullable) | yes | URL to the recording file (supported formats: .mp4, .wav, .m4a) |
 | start_time_utc | string | yes | When the call started, in UTC |
 | participants | array[object] | yes | List of call participants |
 | status | string (enum: INITIALIZING, QUEUED, EVALUATING, COMPLETED, INCOMPLETED) | yes | Enum representing the possible states of a call. |
 | **Variant: `simulation_ended`** | | | |
-| id | integer | yes | The ID of the simulation result |
+| id | integer | yes | The ID of the simulation conversation |
 | digital_human_id | integer | yes | The ID of the digital human |
 | simulation_run_id | integer | yes | The ID of the simulation run that this simulation result belongs to |
 | **Variant: `outbound_simulation_started`** | | | |


### PR DESCRIPTION
Terminology-only pass for the legacy-table teardown. All wire fields, endpoint URLs, and event-type names preserved (test_result_id/call_id keys now described as conversation identifiers). 6 files: call-log + simulation-result endpoint pages, events-webhook payload descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized API reference terminology to “observability conversation” (formerly “call”) and “simulation conversation” (formerly “simulation result”) to align with the legacy-table teardown. No API behavior or field names changed; docs now clarify that `call_id` and `test_result_id` identify conversations across endpoints and webhook payloads.

- **Migration**
  - No API or schema changes; no action required.

<sup>Written for commit a31bc9da532ccdf90bdf7cf6137cf1621482d48d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

