### PR TITLE
docs: Slack community CTAs with current invite

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -77,6 +77,10 @@ flowchart LR
   </Step>
 </Steps>
 
+<Note>
+  Have a question or want to swap notes with other builders? [Join our Slack community](https://join.slack.com/t/bluejaycommunity/shared_invite/zt-442xk85k5-Qkbq65wVOxK~1FHU5OadEA).
+</Note>
+
 ## Why Bluejay
 
 Building a voice agent is easy. Trusting it will work is hard. Engineers have become supervisors, pouring time into verifying their agent's functionality. Without the proper tools, that verification happens in a tedious, manual fashion -- or it doesn't happen at all.

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -390,4 +390,7 @@ Get from account creation to running Simulations, evaluating production calls, a
   <Card title="API Reference" icon="code" href="/api-reference/introduction">
     Full endpoint documentation for every Bluejay API.
   </Card>
+  <Card title="Join the Community" icon="slack" href="https://join.slack.com/t/bluejaycommunity/shared_invite/zt-442xk85k5-Qkbq65wVOxK~1FHU5OadEA">
+    Ask questions, share what you're building, and get help from the Bluejay team and other builders in our Slack.
+  </Card>
 </CardGroup>

--- a/simulation-integrations/sip.mdx
+++ b/simulation-integrations/sip.mdx
@@ -206,4 +206,4 @@ def update_simulation_result(simulation_result_id, tool_calls, metadata):
 ```
 
 </Accordion>
-For any further technical support with SIP configuration or integration questions, contact the Bluejay team.
+For any further technical support with SIP configuration or integration questions, ask in our [Slack community](https://join.slack.com/t/bluejaycommunity/shared_invite/zt-442xk85k5-Qkbq65wVOxK~1FHU5OadEA).

--- a/test/simulations/statuses.mdx
+++ b/test/simulations/statuses.mdx
@@ -132,7 +132,7 @@ When a call doesn't reach **Completed**, it lands in one of five failure buckets
 
     **Who needs to fix it:** Bluejay.
 
-    **What to do:** Reach out to the Bluejay team to learn more about why your call failed. We log every failure and often have a fix in hand before customers reach out, so getting in touch is the fastest way to find out where things stand.
+    **What to do:** Ask in our [Slack community](https://join.slack.com/t/bluejaycommunity/shared_invite/zt-442xk85k5-Qkbq65wVOxK~1FHU5OadEA) to learn more about why your call failed. We log every failure and often have a fix in hand before customers reach out, so getting in touch is the fastest way to find out where things stand.
   </Accordion>
 </AccordionGroup>
 
@@ -167,7 +167,7 @@ A simulation run is **Completed** as soon as there's nothing left to wait on. Th
 | **No Answer** | Your agent isn't picking up | Your agent's phone routing, allowed‑caller‑ID list, online status |
 | **Call Dropped** | Your provider is unstable for a window | Your provider's status page; any recent agent config changes |
 | **Out of Funds** | Bluejay account balance ran out | Your Bluejay billing settings |
-| **System Error** | A Bluejay‑side problem | Reach out to the Bluejay team. We often have a fix in hand before customers ask |
+| **System Error** | A Bluejay‑side problem | Ask in our [Slack community](https://join.slack.com/t/bluejaycommunity/shared_invite/zt-442xk85k5-Qkbq65wVOxK~1FHU5OadEA). We often have a fix in hand before customers ask |
 
 <Tip>
 For any specific failure, click the row in the simulation results table to see the exact error code, a detailed message, and a one‑click action where one is available.


### PR DESCRIPTION
Adds 'Join our Slack community' CTAs on the home page, quickstart, SIP guide, and simulation statuses, all pointing at the current invite (`bluejaycommunity/...zt-442xk85k5`).

Supersedes #262 (`lt-slack-community-cta`): that branch predates the revamp, conflicts on every shared file, and edits `cookbook/observability.mdx` which the revamp deleted. This re-applies the same CTAs cleanly onto current `dev`, minus the deleted page. #262 can be closed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add “Join our Slack community” CTAs across docs to route support questions to the current invite link. Links appear on the home page, quickstart, SIP integration guide, and simulation statuses.

<sup>Written for commit 7bdefa5da5ef6ae8151701f3891407e2615306e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

