### PR TITLE
docs(digital-humans): document phone extension (inbound-agent DTMF)

### DIFF
--- a/key-concepts/digital-humans/configuration.mdx
+++ b/key-concepts/digital-humans/configuration.mdx
@@ -99,6 +99,16 @@ DTMF Sequence: "1" → "4829" → "#"
 Trigger: After the agent says "Please enter your account number followed by the pound sign"
 ```
 
+### Phone Extension
+
+Give a Digital Human an **extension** (the `extension` field) to reach a specific extension after the call connects, the same way you save one on a phone contact. This applies only when the Digital Human calls an **inbound agent**: it dials the agent's number, then plays the extension as DTMF once connected, before the conversation starts. It is ignored for outbound agents, where the agent calls the Digital Human.
+
+Use digits `0-9`, `*`, and `#`. A comma is a short pause, useful when a menu needs a beat before it accepts input.
+
+```md
+Extension: "1,2"   → press 1, pause, press 2
+```
+
 ### Silence Simulation
 
 Configure a Digital Human to **stay silent** for a specified duration. This tests how your agent handles dead air. Does it re-prompt the customer? Does it escalate? Does it hang up too early?


### PR DESCRIPTION
Adds a **Phone Extension** subsection to `key-concepts/digital-humans/configuration.mdx`, next to DTMF Codes.

Documents the new per-digital-human `extension` field: when a digital human calls an **inbound agent**, the extension is dialed as DTMF once the call connects (comma = pause). Ignored for outbound agents.

Pairs with:
- bluejay_middleware #1148
- livekit_agent #689
- bluejay_frontend_v2 #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the per–Digital Human `extension` field to auto-dial a phone extension via DTMF after an inbound-agent call connects. Clarifies that commas add pauses and that the field is ignored for outbound agents.

<sup>Written for commit a78508679b448d6c0ef5907dc393f64e398ebd4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

