### PR TITLE
docs(uptime): add an uptime monitoring page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -257,6 +257,14 @@
                   "monitor/observability/dashboards",
                   "monitor/observability/alerts"
                 ]
+              },
+              {
+                "group": "Uptime",
+                "icon": "heart-pulse",
+                "expanded": false,
+                "pages": [
+                  "monitor/uptime/overview"
+                ]
               }
             ]
           },

--- a/monitor/uptime/overview.mdx
+++ b/monitor/uptime/overview.mdx
@@ -1,0 +1,65 @@
+---
+title: 'Uptime Monitoring'
+description: 'Run a health check against a live agent on a schedule and get paged when it stops answering'
+icon: heart-pulse
+---
+
+An uptime monitor calls or texts one of your live agents on a fixed interval, grades what happened, and records UP or DOWN. When the verdict flips, it notifies Slack, email, or PagerDuty.
+
+It works on voice and SMS agents, inbound and outbound.
+
+## Checks
+
+A monitor grades one or more checks. Every monitor needs at least one check that names what to grade, otherwise there is nothing to measure and the monitor is rejected.
+
+| Check | What it measures |
+|-------|------------------|
+| **Agent Responds** | The call connected and the agent spoke |
+| **Agent Malfunction** | The agent stated an error during the conversation |
+| **Latency** | Average response time stayed under a threshold |
+| **Custom metric** | Any of your custom metrics, scored against a condition |
+
+You can also point a check at one of your own digital humans so the probe uses that persona instead of the default. A digital human on its own is not gradable, so pair it with one of the checks above.
+
+## How latency is measured
+
+Latency is the gap between your caller finishing and your agent starting to speak, averaged across the conversation.
+
+The agent's opening greeting is not included. The first measured gap is the agent's first real answer. Time to greeting is covered by Agent Responds instead.
+
+Latency is not measured on SMS monitors, where reply times are measured in seconds or minutes rather than milliseconds. The check is skipped and does not affect the verdict.
+
+## Alerting after repeated failures
+
+Latency is an average over a single conversation and Agent Malfunction is a judgment call, so one bad result is not always a real problem. Set `alert_after_failures` on a check and it only counts toward DOWN once it has failed that many checks in a row. A single pass resets the count.
+
+```json
+{
+  "id": "latency",
+  "checkType": "latency",
+  "enabled": true,
+  "config": { "latency_threshold_ms": 3000, "alert_after_failures": 3 }
+}
+```
+
+Leave Agent Responds at the default of 1. An agent that cannot be reached is not ambiguous and should page immediately.
+
+## Verdicts
+
+| Verdict | Meaning |
+|---------|---------|
+| **UP** | Every measurable check passed |
+| **DOWN** | At least one check failed |
+| **UNKNOWN** | Nothing could be measured |
+
+Uptime percentage is UP divided by UP plus DOWN. UNKNOWN is excluded, so it never counts for or against you.
+
+Alerts fire only on a measurable flip between UP and DOWN. UNKNOWN never pages.
+
+## Frequency
+
+Pick an interval that comfortably exceeds how long a conversation takes. SMS conversations run for minutes, so use 10 minutes or more; a check that has not finished in five minutes is recorded as UNKNOWN.
+
+## Outbound agents
+
+Bluejay never dials your outbound agent. Something on your side has to start the conversation, which is either Vapi or Retell placing the call automatically, or your own outbound trigger webhook. An outbound agent with neither is rejected, because every check would time out.


### PR DESCRIPTION
Uptime monitoring had no documentation. This adds one page under Monitor.

Covers the bits that have generated support questions this week: which checks are gradable (a free-form description grades nothing), how latency is actually calculated and why the greeting is excluded, `alert_after_failures`, that UNKNOWN never counts toward the uptime percentage, why SMS monitors need a frequency above five minutes, and why an outbound agent needs something on the customer side to start the call.

Two files: the page and its nav entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Uptime Monitoring docs page under Monitor to explain checks, latency, alerting, verdicts, and setup for voice/SMS agents. Clarifies configs like `alert_after_failures` and outbound triggers to reduce support questions.

- **New Features**
  - Added nav group “Uptime” with `monitor/uptime/overview` (icon: heart-pulse).
  - Explained checks and grading (Agent Responds, Malfunction, Latency, Custom metric), latency rules (greeting excluded; SMS latency skipped), and digital human pairing.
  - Documented alerting and verdicts (`alert_after_failures`, UP/DOWN/UNKNOWN and uptime%), plus guidance on frequency (≥10 min for SMS; 5 min timeout) and outbound agent requirements (Vapi/Retell or webhook trigger).

<sup>Written for commit 4fe8d8dc7fb06f457e539afc70263c9c4f1ad081. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

