### PR TITLE
ENG-369 docs: latency on text uptime monitors

### DIFF
--- a/monitor/uptime/overview.mdx
+++ b/monitor/uptime/overview.mdx
@@ -27,7 +27,7 @@ Latency is the gap between your caller finishing and your agent starting to spea
 
 The agent's opening greeting is not included. The first measured gap is the agent's first real answer. Time to greeting is covered by Agent Responds instead.
 
-Latency is not measured on SMS monitors, where reply times are measured in seconds or minutes rather than milliseconds. The check is skipped and does not affect the verdict.
+SMS and webchat monitors measure the same gap, between your message and the agent's reply. Text replies take far longer than voice, so the default threshold there is 60000 ms instead of 3000 ms. Set `latency_threshold_ms` to whatever your agent should beat.
 
 ## Alerting after repeated failures
 


### PR DESCRIPTION
The page said latency is skipped on SMS. It is measured now, on a 60s default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs: SMS and webchat monitors now measure latency between the user’s message and the agent’s reply. Default threshold is 60,000 ms (vs 3,000 ms for voice) and can be changed via `latency_threshold_ms` (ENG-369).

<sup>Written for commit 34361bebef7a15b991347869bb4a743659cdbc31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

