### PR TITLE
docs(api): Issues endpoints

### DIFF
--- a/api-reference/endpoint/get-issue.mdx
+++ b/api-reference/endpoint/get-issue.mdx
@@ -1,0 +1,55 @@
+---
+title: 'Get Issue'
+description: ''
+openapi: 'GET /v1/issues/{issue_id}'
+---
+<div className="ai-prompt-box">
+<div className="ai-prompt-box-header">Integration Prompt for AI Agents</div>
+````
+# Bluejay — Testing & Monitoring Platform for Conversational AI Agents
+
+You are a senior backend engineer integrating the Bluejay API. Think step-by-step: first understand the endpoint, then plan the integration, then implement with minimal changes.
+
+## Get Issue — GET /v1/issues/{issue_id}
+
+> **What this endpoint does:** fetch one issue by id.
+
+**Endpoint:** GET `https://api.getbluejay.ai/v1/issues/{issue_id}`
+**Auth:** `X-API-Key` header
+
+### Required Parameters
+| Name | Type | Description |
+|------|------|-------------|
+| issue_id | string (uuid) | The issue to fetch. |
+| X-API-Key | string | API key required to authenticate requests. |
+
+### Example
+**Simple GET:**
+```python
+import requests
+
+def get_issue(issue_id: str, api_key: str) -> dict:
+    url = f"https://api.getbluejay.ai/v1/issues/{issue_id}"
+    headers = {"X-API-Key": api_key}
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    return response.json()
+```
+
+### Constraints
+- Minimal changes — only add/change files needed for this integration.
+- Match existing codebase patterns (naming, file structure, error handling).
+- Include error handling for 404: Issue not found.
+
+### Integration Checklist
+Before writing code, verify:
+1. Which module/service owns this API domain in the codebase?
+2. What HTTP client and error-handling patterns does the project use?
+3. Are there existing types/interfaces to extend?
+
+Then implement the integration, export it, and confirm it compiles/passes lint.
+````
+</div>
+
+
+Fetch one issue by id. Returns 404 if the issue does not belong to your organization.

--- a/api-reference/endpoint/list-issues.mdx
+++ b/api-reference/endpoint/list-issues.mdx
@@ -22,7 +22,7 @@ You are a senior backend engineer integrating the Bluejay API. Think step-by-ste
 |------|------|-------------|
 | X-API-Key | string | API key required to authenticate requests. |
 
-Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpoint/list-issues and include any optional parameters (e.g., `status`, `priority`, `type`, `assignee_id`) that serve your integration's use case.
+Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpoint/list-issues and include any optional parameters (e.g., `status`, `priority`, `type`, `assignee_id`, `limit`, `offset`) that serve your integration's use case.
 
 ### Example
 **Simple GET:**
@@ -53,8 +53,8 @@ Then implement the integration, export it, and confirm it compiles/passes lint.
 </div>
 
 
-An issue is a problem found across your calls, such as the agent ending a call without confirming the outcome.
+An issue is a problem found across your calls, such as the agent ending a call without confirming the outcome. This endpoint returns only issues that have a title. One-off failures that have not yet grouped are not included.
 
-Bluejay finds issues two ways. A `non_deterministic` issue is grouped from similar failures across many calls. A `deterministic` issue comes from an error the platform recognises outright, such as a tool call returning a 500.
+Bluejay finds issues two ways. A `non_deterministic` issue (Pattern in the dashboard) is grouped from similar failures. It appears after the same problem shows up on 4 distinct calls, and only once it has a title. A `deterministic` issue (Error in the dashboard) comes from an error the platform recognizes outright, such as a tool call returning a 500, and appears as soon as that error is found.
 
-Filter by `status`, `priority`, `type` or `assignee_id`. Results are ordered by when the issue was last seen, newest first.
+Filter by `status`, `priority`, `type` or `assignee_id`. Results are ordered by when the issue was last seen, newest first. Pass `limit` (1 to 200, default 50) and `offset` to walk the list. The dashboard Issues page is not paginated. This list is.

--- a/api-reference/endpoint/list-issues.mdx
+++ b/api-reference/endpoint/list-issues.mdx
@@ -1,0 +1,60 @@
+---
+title: 'List Issues'
+description: ''
+openapi: 'GET /v1/issues'
+---
+<div className="ai-prompt-box">
+<div className="ai-prompt-box-header">Integration Prompt for AI Agents</div>
+````
+# Bluejay — Testing & Monitoring Platform for Conversational AI Agents
+
+You are a senior backend engineer integrating the Bluejay API. Think step-by-step: first understand the endpoint, then plan the integration, then implement with minimal changes.
+
+## List Issues — GET /v1/issues
+
+> **What this endpoint does:** list the problems Bluejay found on your calls, most recently seen first.
+
+**Endpoint:** GET `https://api.getbluejay.ai/v1/issues`
+**Auth:** `X-API-Key` header
+
+### Required Parameters
+| Name | Type | Description |
+|------|------|-------------|
+| X-API-Key | string | API key required to authenticate requests. |
+
+Review the full parameter list at https://docs.getbluejay.ai/api-reference/endpoint/list-issues and include any optional parameters (e.g., `status`, `priority`, `type`, `assignee_id`) that serve your integration's use case.
+
+### Example
+**Simple GET:**
+```python
+import requests
+
+def list_open_issues(api_key: str) -> dict:
+    url = "https://api.getbluejay.ai/v1/issues"
+    headers = {"X-API-Key": api_key}
+    response = requests.get(url, headers=headers, params={"status": "open"})
+    response.raise_for_status()
+    return response.json()
+```
+
+### Constraints
+- Minimal changes — only add/change files needed for this integration.
+- Match existing codebase patterns (naming, file structure, error handling).
+- Include error handling for 422: Validation Error.
+
+### Integration Checklist
+Before writing code, verify:
+1. Which module/service owns this API domain in the codebase?
+2. What HTTP client and error-handling patterns does the project use?
+3. Are there existing types/interfaces to extend?
+
+Then implement the integration, export it, and confirm it compiles/passes lint.
+````
+</div>
+
+
+An issue is a problem found across your calls, such as the agent ending a call without confirming the outcome.
+
+Bluejay finds issues two ways. A `non_deterministic` issue is grouped from similar failures across many calls. A `deterministic` issue comes from an error the platform recognises outright, such as a tool call returning a 500.
+
+Filter by `status`, `priority`, `type` or `assignee_id`. Results are ordered by when the issue was last seen, newest first.

--- a/api-reference/endpoint/list-issues.mdx
+++ b/api-reference/endpoint/list-issues.mdx
@@ -55,6 +55,6 @@ Then implement the integration, export it, and confirm it compiles/passes lint.
 
 An issue is a problem found across your calls, such as the agent ending a call without confirming the outcome. This endpoint returns only issues that have a title. One-off failures that have not yet grouped are not included.
 
-Bluejay finds issues two ways. A `non_deterministic` issue (Pattern in the dashboard) is grouped from similar failures. It appears after the same problem shows up on 4 distinct calls, and only once it has a title. A `deterministic` issue (Error in the dashboard) comes from an error the platform recognizes outright, such as a tool call returning a 500, and appears as soon as that error is found.
+Bluejay finds issues two ways. A `non_deterministic` issue (Pattern in the dashboard) is grouped from similar failures. It appears once the same problem recurs across calls, and only once it has a title. A `deterministic` issue (Error in the dashboard) comes from an error the platform recognizes outright, such as a tool call returning a 500, and appears as soon as that error is found.
 
 Filter by `status`, `priority`, `type` or `assignee_id`. Results are ordered by when the issue was last seen, newest first. Pass `limit` (1 to 200, default 50) and `offset` to walk the list. The dashboard Issues page is not paginated. This list is.

--- a/api-reference/endpoint/update-issue.mdx
+++ b/api-reference/endpoint/update-issue.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Update Issue'
 description: ''
-openapi: 'PATCH /v1/issues/{issue_id}'
+openapi: 'PUT /v1/issues/{issue_id}'
 ---
 <div className="ai-prompt-box">
 <div className="ai-prompt-box-header">Integration Prompt for AI Agents</div>
@@ -10,11 +10,11 @@ openapi: 'PATCH /v1/issues/{issue_id}'
 
 You are a senior backend engineer integrating the Bluejay API. Think step-by-step: first understand the endpoint, then plan the integration, then implement with minimal changes.
 
-## Update Issue — PATCH /v1/issues/{issue_id}
+## Update Issue — PUT /v1/issues/{issue_id}
 
 > **What this endpoint does:** set an issue's status, priority, assignee or due date.
 
-**Endpoint:** PATCH `https://api.getbluejay.ai/v1/issues/{issue_id}`
+**Endpoint:** PUT `https://api.getbluejay.ai/v1/issues/{issue_id}`
 **Auth:** `X-API-Key` header
 
 ### Required Parameters
@@ -34,14 +34,14 @@ def resolve_issue(issue_id: str, assignee_id: str, api_key: str) -> dict:
     url = f"https://api.getbluejay.ai/v1/issues/{issue_id}"
     headers = {"X-API-Key": api_key}
     body = {"status": "resolved", "assignee_id": assignee_id}
-    response = requests.patch(url, headers=headers, json=body)
+    response = requests.put(url, headers=headers, json=body)
     response.raise_for_status()
     return response.json()
 ```
 
 **Unset a field:**
 ```python
-requests.patch(url, headers=headers, json={"clear": ["priority", "due_date"]})
+requests.put(url, headers=headers, json={"priority": None, "due_date": None})
 ```
 
 ### Constraints
@@ -62,10 +62,10 @@ Then implement the integration, export it, and confirm it compiles/passes lint.
 
 Set an issue's `status`, `priority`, `assignee_id` or `due_date`. Every field is optional, so send only what you want to change.
 
-To unset a field, list it in `clear` rather than sending null:
+Send a field as `null` to unset it. A field you leave out is untouched:
 
 ```json
-{ "status": "open", "clear": ["assignee_id"] }
+{ "status": "open", "assignee_id": null }
 ```
 
 `status` is one of `open`, `in_progress`, `resolved` or `ignored`. `priority` is one of `low`, `medium`, `high` or `urgent`, and stays empty until someone sets it. `assignee_id` must be a user in your organization. `due_date` is `YYYY-MM-DD`.

--- a/api-reference/endpoint/update-issue.mdx
+++ b/api-reference/endpoint/update-issue.mdx
@@ -68,6 +68,6 @@ To unset a field, list it in `clear` rather than sending null:
 { "status": "open", "clear": ["assignee_id"] }
 ```
 
-`status` is one of `open`, `resolved` or `ignored`. `priority` is one of `low`, `medium`, `high` or `urgent`, and stays empty until someone sets it. `assignee_id` must be a user in your organization. `due_date` is `YYYY-MM-DD`.
+`status` is one of `open`, `in_progress`, `resolved` or `ignored`. `priority` is one of `low`, `medium`, `high` or `urgent`, and stays empty until someone sets it. `assignee_id` must be a user in your organization. `due_date` is `YYYY-MM-DD`.
 
 An issue's title, and the calls attached to it, are produced by Bluejay and cannot be edited.

--- a/api-reference/endpoint/update-issue.mdx
+++ b/api-reference/endpoint/update-issue.mdx
@@ -1,0 +1,73 @@
+---
+title: 'Update Issue'
+description: ''
+openapi: 'PATCH /v1/issues/{issue_id}'
+---
+<div className="ai-prompt-box">
+<div className="ai-prompt-box-header">Integration Prompt for AI Agents</div>
+````
+# Bluejay — Testing & Monitoring Platform for Conversational AI Agents
+
+You are a senior backend engineer integrating the Bluejay API. Think step-by-step: first understand the endpoint, then plan the integration, then implement with minimal changes.
+
+## Update Issue — PATCH /v1/issues/{issue_id}
+
+> **What this endpoint does:** set an issue's status, priority, assignee or due date.
+
+**Endpoint:** PATCH `https://api.getbluejay.ai/v1/issues/{issue_id}`
+**Auth:** `X-API-Key` header
+
+### Required Parameters
+| Name | Type | Description |
+|------|------|-------------|
+| issue_id | string (uuid) | The issue to update. |
+| X-API-Key | string | API key required to authenticate requests. |
+
+Every body field is optional. Only the fields you send are changed.
+
+### Example
+**Resolve an issue and set its owner:**
+```python
+import requests
+
+def resolve_issue(issue_id: str, assignee_id: str, api_key: str) -> dict:
+    url = f"https://api.getbluejay.ai/v1/issues/{issue_id}"
+    headers = {"X-API-Key": api_key}
+    body = {"status": "resolved", "assignee_id": assignee_id}
+    response = requests.patch(url, headers=headers, json=body)
+    response.raise_for_status()
+    return response.json()
+```
+
+**Unset a field:**
+```python
+requests.patch(url, headers=headers, json={"clear": ["priority", "due_date"]})
+```
+
+### Constraints
+- Minimal changes — only add/change files needed for this integration.
+- Match existing codebase patterns (naming, file structure, error handling).
+- Include error handling for 400: Validation Error and 404: Issue not found.
+
+### Integration Checklist
+Before writing code, verify:
+1. Which module/service owns this API domain in the codebase?
+2. What HTTP client and error-handling patterns does the project use?
+3. Are there existing types/interfaces to extend?
+
+Then implement the integration, export it, and confirm it compiles/passes lint.
+````
+</div>
+
+
+Set an issue's `status`, `priority`, `assignee_id` or `due_date`. Every field is optional, so send only what you want to change.
+
+To unset a field, list it in `clear` rather than sending null:
+
+```json
+{ "status": "open", "clear": ["assignee_id"] }
+```
+
+`status` is one of `open`, `resolved` or `ignored`. `priority` is one of `low`, `medium`, `high` or `urgent`, and stays empty until someone sets it. `assignee_id` must be a user in your organization. `due_date` is `YYYY-MM-DD`.
+
+An issue's title, and the calls attached to it, are produced by Bluejay and cannot be edited.

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,14 @@ icon: clock
 rss: true
 ---
 
+<Update label="August 19th, 2026" tags={["New", "Observability"]}>
+  ## Issues
+
+  Production failures now group into Issues you can triage. Patterns appear after the same problem shows up on 4 distinct calls, with a title. Known errors (a tool 500, a tool that should have run but never did) appear as soon as they are recognized. Open Monitor → Issues for the full list, grouped by status. The list is not paginated.
+
+  [Issues](/monitor/observability/issues) · [List Issues API](/api-reference/endpoint/list-issues)
+</Update>
+
 <Update label="June 23rd, 2026" tags={["New", "Integration"]}>
   ## Google Dialogflow CX integration
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -8,9 +8,9 @@ rss: true
 <Update label="August 19th, 2026" tags={["New", "Observability"]}>
   ## Issues
 
-  Production failures now group into Issues you can triage. Patterns appear after the same problem shows up on 4 distinct calls, with a title. Known errors (a tool 500, a tool that should have run but never did) appear as soon as they are recognized. Open Monitor → Issues for the full list, grouped by status. The list is not paginated.
+  Production failures now group into Issues you can triage. Patterns appear once the same problem recurs across calls, with a title. Known errors (a tool 500, a tool that should have run but never did) appear as soon as they are recognized. Open Monitor → Issues for the full list, grouped by status. The list is not paginated.
 
-  [Issues](/monitor/observability/issues) · [List Issues API](/api-reference/endpoint/list-issues)
+  [Issues](/key-concepts/issues/overview) · [Monitor → Issues](/monitor/observability/issues) · [List Issues API](/api-reference/endpoint/list-issues)
 </Update>
 
 <Update label="June 23rd, 2026" tags={["New", "Integration"]}>

--- a/docs.json
+++ b/docs.json
@@ -278,6 +278,14 @@
                 ]
               },
               {
+                "group": "Issues",
+                "icon": "triangle-exclamation",
+                "expanded": false,
+                "pages": [
+                  "key-concepts/issues/overview"
+                ]
+              },
+              {
                 "group": "Customer Traits",
                 "icon": "id-card",
                 "expanded": false,

--- a/docs.json
+++ b/docs.json
@@ -404,6 +404,7 @@
                   "monitor/observability/traces",
                   "key-concepts/webhooks/overview",
                   "monitor/observability/dashboards",
+                  "monitor/observability/issues",
                   "monitor/observability/alerts"
                 ]
               },

--- a/docs.json
+++ b/docs.json
@@ -719,6 +719,16 @@
                 ]
               },
               {
+                "group": "Issues",
+                "icon": "triangle-exclamation",
+                "expanded": false,
+                "pages": [
+                  "api-reference/endpoint/list-issues",
+                  "api-reference/endpoint/get-issue",
+                  "api-reference/endpoint/update-issue"
+                ]
+              },
+              {
                 "group": "Labels",
                 "icon": "tags",
                 "expanded": false,

--- a/glossary.mdx
+++ b/glossary.mdx
@@ -14,7 +14,7 @@ icon: list-tree
       className="w-full bg-transparent py-2.5 text-sm text-slate-900 placeholder:text-slate-400 dark:text-white dark:placeholder:text-slate-500"
     />
   </div>
-  <p className="mt-2 text-xs text-slate-400 dark:text-slate-500"><span id="glossary-results-count">49</span> terms</p>
+  <p className="mt-2 text-xs text-slate-400 dark:text-slate-500"><span id="glossary-results-count">50</span> terms</p>
 </div>
 
 <div id="glossary-empty-state" className="not-prose mb-10 hidden py-10 text-center">
@@ -160,6 +160,18 @@ See more: [Custom Metrics](/key-concepts/custom-metrics/overview) | [Metrics Lab
 When an agent provides incorrect or fabricated information that contradicts its knowledge base. Bluejay detects hallucinations automatically during evaluation and includes reasoning for each finding.
 
 See more: [Observability](/monitor/observability/overview) | [Observability Overview](/monitor/observability/overview)
+</Accordion></div>
+</section>
+
+<section id="i" data-glossary-section className="not-prose mb-12 scroll-mt-28">
+  <div className="mb-4 flex items-center justify-between gap-4">
+    <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">I</h2>
+    <span className="rounded-full border border-slate-200 px-3 py-1 text-sm text-slate-500 dark:border-white/10 dark:text-slate-400">1 term</span>
+  </div>
+  <div data-glossary-item data-term="Issue"><Accordion title="Issue">
+A grouped production failure you can triage. Patterns appear once the same problem recurs across calls, with a title. Errors (a known failure such as a tool 500) appear as soon as they are recognized.
+
+See more: [Issues Overview](/key-concepts/issues/overview) | [Monitor → Issues](/monitor/observability/issues) | [List Issues API](/api-reference/endpoint/list-issues)
 </Accordion></div>
 </section>
 

--- a/index.mdx
+++ b/index.mdx
@@ -58,6 +58,13 @@ flowchart LR
   >
     Get notified the moment your agent fails a metric so you can act on issues before customers pile up.
   </Card>
+  <Card
+    title="Issues"
+    icon="triangle-exclamation"
+    href="/key-concepts/issues/overview"
+  >
+    Recurring production failures, grouped so you can triage a pattern instead of a single call.
+  </Card>
 </CardGroup>
 
 ## Getting Started

--- a/key-concepts/alerts/overview.mdx
+++ b/key-concepts/alerts/overview.mdx
@@ -75,4 +75,7 @@ For critical metrics like hallucination detection, set occurrences to 1 so the a
   <Card title="Custom Metrics" icon="gauge-high" href="/key-concepts/custom-metrics/overview">
     Define the metrics that power your alert thresholds.
   </Card>
+  <Card title="Issues" icon="triangle-exclamation" href="/key-concepts/issues/overview">
+    Recurring failures grouped for triage, not threshold notifications.
+  </Card>
 </CardGroup>

--- a/key-concepts/issues/overview.mdx
+++ b/key-concepts/issues/overview.mdx
@@ -1,0 +1,84 @@
+---
+title: Overview
+description: Understand how Issues group recurring production failures
+icon: triangle-exclamation
+---
+
+Issues group what went wrong on production calls so you can own a pattern instead of hunting through logs. They are built from [observability](/monitor/observability/overview) evaluations. Open **Monitor → Issues**.
+
+## Where Issues sit
+
+Each evaluated production call is scored and checked for failures. [Custom Metrics](/key-concepts/custom-metrics/overview) feed [alerts](/key-concepts/alerts/overview). Failures feed Issues.
+
+```mermaid
+flowchart LR
+    Call[Production call evaluated] --> Metrics[Custom Metrics]
+    Call --> Failures[Failures]
+    Metrics --> Alert[Alerts]
+    Failures --> Issue[Issues]
+```
+
+Alerts notify you when a metric crosses a threshold. Issues collect the failures themselves so you can assign, prioritize, and close them.
+
+## How Issues appear
+
+Bluejay finds issues two ways. The list labels them **Pattern** and **Error**.
+
+```mermaid
+flowchart LR
+    Call[Call evaluated] --> Fail{Failure found?}
+    Fail -->|No| Skip[Nothing listed]
+    Fail -->|Known error| Error[Error appears now]
+    Fail -->|Similar problem| Recur{Recurring?}
+    Recur -->|One-off| Hidden[Not listed]
+    Recur -->|Yes| Pattern[Pattern appears with a title]
+```
+
+| Kind | When it shows | Example |
+|------|----------------|---------|
+| **Pattern** | Once the same problem recurs across calls, and only once it has a title | The agent ends the call without confirming the outcome |
+| **Error** | As soon as Bluejay recognizes a known failure | A tool returns a 500, or a tool that should have run never does |
+
+A one-off Pattern does not appear. That is expected. Until it has a title, it is not listed anywhere, including the API.
+
+If a new failure matches an issue you already have, the calls join that issue. An issue that goes quiet stays on the list. Last Seen tells you how recently it happened.
+
+Errors often come from [tool calls](/monitor/observability/tool-calls) sent with the [evaluate](/api-reference/endpoint/evaluate) request.
+
+## What you can change
+
+Set status, priority, assignee, and due date. Status is Open, In Progress, Resolved, or Ignored. Priority stays empty until someone sets it.
+
+The title and the calls attached to an issue are produced by Bluejay. You cannot edit them.
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="Using Issues" icon="list" href="/monitor/observability/issues">
+    The Monitor → Issues list, filters, and triage.
+  </Card>
+  <Card title="Observability" icon="eye" href="/monitor/observability/overview">
+    How production calls get into Bluejay.
+  </Card>
+  <Card title="Alerts" icon="bell" href="/key-concepts/alerts/overview">
+    Threshold notifications when a metric crosses a boundary.
+  </Card>
+  <Card title="Custom Metrics" icon="gauge-high" href="/key-concepts/custom-metrics/overview">
+    The scores that power alerts.
+  </Card>
+  <Card title="Tool Calls" icon="wrench" href="/monitor/observability/tool-calls">
+    Include tool data so Errors like a 500 can be recognized.
+  </Card>
+  <Card title="Traces" icon="route" href="/key-concepts/traces/overview">
+    Send OpenTelemetry traces with production calls.
+  </Card>
+  <Card title="Webhooks" icon="bolt" href="/key-concepts/webhooks/overview">
+    Ingest calls and receive evaluation events.
+  </Card>
+  <Card title="List Issues API" icon="code" href="/api-reference/endpoint/list-issues">
+    List, filter, and page issues. Newest last-seen first.
+  </Card>
+  <Card title="Update Issue API" icon="pen" href="/api-reference/endpoint/update-issue">
+    Set status, priority, assignee, or due date.
+  </Card>
+</CardGroup>

--- a/monitor/observability/issues.mdx
+++ b/monitor/observability/issues.mdx
@@ -1,0 +1,51 @@
+---
+title: 'Issues'
+description: 'See recurring failures across production calls, then triage them'
+icon: triangle-exclamation
+---
+
+Issues group what went wrong on your production calls so you can own a pattern instead of hunting through logs. Open **Monitor → Issues**.
+
+The page lists every issue that has a title. It is not paginated. Rows are grouped under Open, In Progress, Resolved, and Ignored. The count on each header is the full filtered set. Collapsing a section hides its rows.
+
+## How issues appear
+
+Bluejay finds issues two ways. The dashboard labels them Pattern and Error.
+
+| Kind | When it shows | Example |
+|------|----------------|---------|
+| **Pattern** | After the same problem shows up on 4 distinct calls, and only once it has a title | The agent ends the call without confirming the outcome |
+| **Error** | As soon as Bluejay recognizes a known failure | A tool returns a 500, or a tool that should have run never does |
+
+A one-off Pattern does not appear. That is expected. Until it has a title, it is not listed anywhere, including the API.
+
+If a new failure is already the same as an issue you have, the calls join that issue instead of creating another. An issue that goes quiet stays on the list. Last Seen tells you how recently it happened.
+
+## What you can change
+
+Set status, priority, assignee, and due date from the list or the issue page. Status is Open, In Progress, Resolved, or Ignored. Priority stays empty until someone sets it.
+
+The title and the calls attached to an issue are produced by Bluejay. You cannot edit them.
+
+## Filters
+
+Search, agent, Pattern vs Error, source, and status. The list is the full filtered set, not a page of results.
+
+## API
+
+The same issues are available over the API. List results are newest last-seen first, 50 at a time by default.
+
+<CardGroup cols={2}>
+  <Card title="List Issues" icon="list" href="/api-reference/endpoint/list-issues">
+    List issues. Filter by status, priority, type, or assignee.
+  </Card>
+  <Card title="Get Issue" icon="file-lines" href="/api-reference/endpoint/get-issue">
+    Fetch one issue by id.
+  </Card>
+  <Card title="Update Issue" icon="pen" href="/api-reference/endpoint/update-issue">
+    Set status, priority, assignee, or due date.
+  </Card>
+  <Card title="Observability Overview" icon="eye" href="/monitor/observability/overview">
+    How production calls get into Bluejay.
+  </Card>
+</CardGroup>

--- a/monitor/observability/issues.mdx
+++ b/monitor/observability/issues.mdx
@@ -1,41 +1,31 @@
 ---
 title: 'Issues'
-description: 'See recurring failures across production calls, then triage them'
+description: 'Triage recurring production failures from Monitor → Issues'
 icon: triangle-exclamation
 ---
 
-Issues group what went wrong on your production calls so you can own a pattern instead of hunting through logs. Open **Monitor → Issues**.
+Open **Monitor → Issues** to own a pattern instead of hunting through logs. What Issues are, and how Pattern vs Error works, is in [Issues Overview](/key-concepts/issues/overview).
 
 The page lists every issue that has a title. It is not paginated. Rows are grouped under Open, In Progress, Resolved, and Ignored. The count on each header is the full filtered set. Collapsing a section hides its rows.
-
-## How issues appear
-
-Bluejay finds issues two ways. The dashboard labels them Pattern and Error.
-
-| Kind | When it shows | Example |
-|------|----------------|---------|
-| **Pattern** | After the same problem shows up on 4 distinct calls, and only once it has a title | The agent ends the call without confirming the outcome |
-| **Error** | As soon as Bluejay recognizes a known failure | A tool returns a 500, or a tool that should have run never does |
-
-A one-off Pattern does not appear. That is expected. Until it has a title, it is not listed anywhere, including the API.
-
-If a new failure is already the same as an issue you have, the calls join that issue instead of creating another. An issue that goes quiet stays on the list. Last Seen tells you how recently it happened.
-
-## What you can change
-
-Set status, priority, assignee, and due date from the list or the issue page. Status is Open, In Progress, Resolved, or Ignored. Priority stays empty until someone sets it.
-
-The title and the calls attached to an issue are produced by Bluejay. You cannot edit them.
 
 ## Filters
 
 Search, agent, Pattern vs Error, source, and status. The list is the full filtered set, not a page of results.
+
+## Triage
+
+Set status, priority, assignee, and due date from the list or the issue page. Status is Open, In Progress, Resolved, or Ignored. Priority stays empty until someone sets it.
+
+The title and the calls attached to an issue are produced by Bluejay. You cannot edit them.
 
 ## API
 
 The same issues are available over the API. List results are newest last-seen first, 50 at a time by default.
 
 <CardGroup cols={2}>
+  <Card title="Issues Overview" icon="triangle-exclamation" href="/key-concepts/issues/overview">
+    What Issues are, Pattern vs Error, and how they differ from Alerts.
+  </Card>
   <Card title="List Issues" icon="list" href="/api-reference/endpoint/list-issues">
     List issues. Filter by status, priority, type, or assignee.
   </Card>
@@ -44,8 +34,5 @@ The same issues are available over the API. List results are newest last-seen fi
   </Card>
   <Card title="Update Issue" icon="pen" href="/api-reference/endpoint/update-issue">
     Set status, priority, assignee, or due date.
-  </Card>
-  <Card title="Observability Overview" icon="eye" href="/monitor/observability/overview">
-    How production calls get into Bluejay.
   </Card>
 </CardGroup>

--- a/monitor/observability/overview.mdx
+++ b/monitor/observability/overview.mdx
@@ -38,6 +38,7 @@ You can send conversations to Bluejay via the evaluate API, webhooks, or native 
 - **Custom Metric scores** -- every metric you've defined is evaluated and scored
 - **Token and latency data** -- operational signals for understanding performance
 - **Full transcripts** -- stored and searchable for detailed investigation
+- **Issues** -- recurring failures grouped so you can triage a pattern instead of a single call. See [Issues](/monitor/observability/issues).
 
 ## Ingestion Methods
 
@@ -64,5 +65,8 @@ You can send conversations to Bluejay via the evaluate API, webhooks, or native 
   </Card>
   <Card title="Webhooks" icon="bolt" href="/key-concepts/webhooks/overview">
     Receive real-time notifications for evaluation events.
+  </Card>
+  <Card title="Issues" icon="triangle-exclamation" href="/monitor/observability/issues">
+    Recurring failures across production calls, ready to triage.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## What's in this PR
- **Issues API pages.** `GET /v1/issues`, `GET /v1/issues/{id}`, `PUT /v1/issues/{id}`, rendered from the live OpenAPI with worked examples.
- **Update is PUT, and `null` unsets.** Drops PATCH + `clear`. Matches dashboards/labels. `null` unsets priority, assignee, or due date.
- **Monitor → Issues.** When a Pattern vs Error appears (4 distinct calls with a title vs immediately on a known failure), what you can change, and filters.
- **Nav.** Issues group beside Labels, plus a changelog line.

Do not merge before the middleware OpenAPI publishes these paths.

## Test plan
- [ ] Pages render against the live spec once middleware has shipped the routes.
- [ ] Nav shows Issues under Monitor / API reference.