### PR TITLE
SEO: 48 redirects, 74 API descriptions, 24 duplicate titles (#288)

### DIFF
--- a/api-reference/endpoint/add-agent.mdx
+++ b/api-reference/endpoint/add-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Add Agent'
-description: ''
+description: "Add a new agent to the system. Returns the agent ID and a status code."
 openapi: 'POST /v1/add-agent'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/add-digital-humans-to-simulation.mdx
+++ b/api-reference/endpoint/add-digital-humans-to-simulation.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Add Digital Humans to Simulation'
-description: ''
+description: "Add existing digital humans to a simulation without replacing existing associations."
 openapi: 'POST /v1/simulation/{simulation_id}/add-digital-humans'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/add-to-community.mdx
+++ b/api-reference/endpoint/add-to-community.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Add Digital Humans To Community'
-description: ''
+description: "Add digital humans to an existing community without replacing the current list."
 openapi: 'PUT /v1/add-to-community/{community_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/create-community.mdx
+++ b/api-reference/endpoint/create-community.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Create Community'
-description: ''
+description: "Create a new community."
 openapi: 'POST /v1/create-community'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/create-custom-metric.mdx
+++ b/api-reference/endpoint/create-custom-metric.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Create Custom Metric'
-description: ''
+description: "Create a new custom metric."
 openapi: 'POST /v1/create-custom-metric'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/create-custom-metrics.mdx
+++ b/api-reference/endpoint/create-custom-metrics.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Create Custom Metrics'
-description: ''
+description: "Create multiple custom metrics synchronously using a single bulk insert."
 openapi: 'POST /v1/create-custom-metrics'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/create-customer-persona.mdx
+++ b/api-reference/endpoint/create-customer-persona.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Create Customer Persona'
-description: ''
+description: "Create a new customer persona."
 openapi: 'POST /v1/create-customer-persona'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/create-digital-human.mdx
+++ b/api-reference/endpoint/create-digital-human.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Create Digital Human'
-description: ''
+description: "Create a new digital human."
 openapi: 'POST /v1/create-digital-human'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/create-folder.mdx
+++ b/api-reference/endpoint/create-folder.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Create Folder'
-description: ''
+description: "Create a new folder for organizing agents. Returns the created folder details."
 openapi: 'POST /v1/create-folder'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/create-label.mdx
+++ b/api-reference/endpoint/create-label.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Create Label'
-description: ''
+description: "Create a free-standing label for an agent (not attached to any prompt or knowledge base)."
 openapi: 'POST /v1/agents/{agent_id}/labels'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/create-prompt-version.mdx
+++ b/api-reference/endpoint/create-prompt-version.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Create Prompt Version'
-description: ''
+description: "Create a new prompt version under /agents/{agent_id}/prompts/versions."
 openapi: 'POST /v1/agents/{agent_id}/prompts/versions'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/create-simulation.mdx
+++ b/api-reference/endpoint/create-simulation.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Create Simulation'
-description: ''
+description: "Create a new simulation with the provided details. Returns the simulation ID and a status code."
 openapi: 'POST /v1/create-simulation'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/delete-agent.mdx
+++ b/api-reference/endpoint/delete-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Delete Agent'
-description: ''
+description: "Delete an agent by ID."
 openapi: 'DELETE /v1/agent/{agent_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/delete-call-log.mdx
+++ b/api-reference/endpoint/delete-call-log.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Delete Call Log'
-description: ''
+description: "Delete a specific call log given its ID. Validates that the user has access to the call log by checking organization membership."
 openapi: 'DELETE /v1/call-log/{call_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/delete-community.mdx
+++ b/api-reference/endpoint/delete-community.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Delete Community'
-description: ''
+description: "Delete a specific community by ID."
 openapi: 'DELETE /v1/community/{community_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/delete-custom-metric.mdx
+++ b/api-reference/endpoint/delete-custom-metric.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Delete Custom Metric'
-description: ''
+description: "Delete a specific custom metric by ID."
 openapi: 'DELETE /v1/custom-metric/{metric_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/delete-customer-persona.mdx
+++ b/api-reference/endpoint/delete-customer-persona.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Delete Customer Persona'
-description: ''
+description: "Delete a specific customer persona by ID."
 openapi: 'DELETE /v1/customer-persona/{persona_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/delete-digital-human.mdx
+++ b/api-reference/endpoint/delete-digital-human.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Delete Digital Human'
-description: ''
+description: "Delete a digital human by ID."
 openapi: 'DELETE /v1/digital-human/{digital_human_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/delete-folder.mdx
+++ b/api-reference/endpoint/delete-folder.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Delete Folder'
-description: ''
+description: "Delete a folder."
 openapi: 'DELETE /v1/folder/{folder_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/delete-label.mdx
+++ b/api-reference/endpoint/delete-label.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Delete Label'
-description: ''
+description: "Delete a free-standing label; cannot delete reserved labels; cannot delete if associated."
 openapi: 'DELETE /v1/agents/{agent_id}/labels/{label_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/delete-prompt-version-by-label.mdx
+++ b/api-reference/endpoint/delete-prompt-version-by-label.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Delete Prompt Version By Label'
-description: ''
+description: "Delete a prompt version by label."
 openapi: 'DELETE /v1/agents/{agent_id}/prompts/versions'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/delete-prompt-version.mdx
+++ b/api-reference/endpoint/delete-prompt-version.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Delete Prompt Version'
-description: ''
+description: "Delete a specific prompt version; cannot delete production; cannot delete only version. If deleting latest, reassign latest to highest remaining version."
 openapi: 'DELETE /v1/agents/{agent_id}/prompts/versions/{version}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/delete-simulation.mdx
+++ b/api-reference/endpoint/delete-simulation.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Delete Simulation'
-description: ''
+description: "Delete a specific simulation by ID."
 openapi: 'DELETE /v1/simulation/{simulation_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/end-conversations.mdx
+++ b/api-reference/endpoint/end-conversations.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'End Conversations'
-description: ''
+description: "End multiple running conversations by marking them in Redis for the LiveKit agent to terminate."
 openapi: 'POST /v1/end-conversations'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/evaluate.mdx
+++ b/api-reference/endpoint/evaluate.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Evaluate'
+description: "Submit a call or chat for evaluation. Returns an eval ID that can be used to track evaluation status."
 openapi: 'POST /v1/evaluate'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/generate-digital-humans.mdx
+++ b/api-reference/endpoint/generate-digital-humans.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Generate Digital Humans'
-description: ''
+description: "Given an agent this endpoint generates digital humans to test that agent based on varying simulation types."
 openapi: 'POST /v1/generate-digital-humans'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-agent-by-external-id.mdx
+++ b/api-reference/endpoint/get-agent-by-external-id.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Agent By External ID'
-description: ''
+description: "Get an agent by external ID."
 openapi: 'GET /v1/agent-by-external-id/{external_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-agent.mdx
+++ b/api-reference/endpoint/get-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Agent'
-description: ''
+description: "Get an agent by ID."
 openapi: 'GET /v1/agents/{agent_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-agents-by-folder.mdx
+++ b/api-reference/endpoint/get-agents-by-folder.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Agents by Folder'
-description: ''
+description: "Get all agents in a specific folder. Returns a list of agent IDs and names in the folder."
 openapi: 'GET /v1/get-agents-by-folder/{folder_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-all-agents.mdx
+++ b/api-reference/endpoint/get-all-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get All Agents'
-description: ''
+description: "Get all your agents."
 openapi: 'GET /v1/all-agents'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-all-digital-humans.mdx
+++ b/api-reference/endpoint/get-all-digital-humans.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get All Digital Humans'
-description: ''
+description: "Get a paginated list of all digital humans in your organization."
 openapi: 'GET /v1/digital-humans'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-all-folders.mdx
+++ b/api-reference/endpoint/get-all-folders.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get All Folders'
-description: ''
+description: "Get all folders for the authenticated user's organization. Returns a list of all folders with their details."
 openapi: 'GET /v1/all-folders'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-all-simulations.mdx
+++ b/api-reference/endpoint/get-all-simulations.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get All Simulations'
-description: ''
+description: "Get all simulations for a user."
 openapi: 'GET /v1/get-all-simulations'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-communities.mdx
+++ b/api-reference/endpoint/get-communities.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Communities'
-description: ''
+description: "Get all communities, optionally filtered by digital human (test case)."
 openapi: 'GET /v1/communities'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-community.mdx
+++ b/api-reference/endpoint/get-community.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Community'
-description: ''
+description: "Get a specific community by ID."
 openapi: 'GET /v1/community/{community_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-custom-metric.mdx
+++ b/api-reference/endpoint/get-custom-metric.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Custom Metric'
-description: ''
+description: "Get a specific custom metric by ID."
 openapi: 'GET /v1/custom-metric/{metric_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-custom-metrics-by-agent.mdx
+++ b/api-reference/endpoint/get-custom-metrics-by-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Custom Metrics by Agent'
-description: ''
+description: "Get all custom metrics for an agent. DEPRECATED: This endpoint is deprecated."
 openapi: 'GET /v1/custom-metrics-by-agent/{agent_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-custom-metrics.mdx
+++ b/api-reference/endpoint/get-custom-metrics.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Custom Metrics'
-description: ''
+description: "Get all custom metrics, optionally filtered by agent, with pagination."
 openapi: 'GET /v1/custom-metrics'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-customer-persona-by-agent.mdx
+++ b/api-reference/endpoint/get-customer-persona-by-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Customer Personas by Agent'
-description: ''
+description: "Get all customer personas for an agent."
 openapi: 'GET /v1/customer-personas-by-agent/{agent_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-customer-persona.mdx
+++ b/api-reference/endpoint/get-customer-persona.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Customer Persona'
-description: ''
+description: "Get a specific customer persona by ID."
 openapi: 'GET /v1/customer-persona/{persona_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-digital-human.mdx
+++ b/api-reference/endpoint/get-digital-human.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Digital Human'
-description: ''
+description: "Get a digital human by ID."
 openapi: 'GET /v1/digital-human/{digital_human_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-digital-humans-by-simulation.mdx
+++ b/api-reference/endpoint/get-digital-humans-by-simulation.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Digital Humans by Simulation'
-description: ''
+description: "Get digital humans by simulation ID."
 openapi: 'GET /v1/digital-humans-by-simulation/{simulation_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-folder.mdx
+++ b/api-reference/endpoint/get-folder.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Folder'
-description: ''
+description: "Get a specific folder by ID. Returns the folder details if it exists and belongs to the user's organization."
 openapi: 'GET /v1/folder/{folder_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-prompt-by-label.mdx
+++ b/api-reference/endpoint/get-prompt-by-label.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Prompt By Label'
-description: ''
+description: "Retrieve a single prompt by label under /agents/{agent_id}/prompts?label=... ."
 openapi: 'GET /v1/agents/{agent_id}/prompts'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-simulation-runs.mdx
+++ b/api-reference/endpoint/get-simulation-runs.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Simulation Runs'
-description: ''
+description: "Get all simulation runs for a specific simulation."
 openapi: 'GET /v1/get-simulation-runs/{simulation_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-simulation.mdx
+++ b/api-reference/endpoint/get-simulation.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Simulation'
-description: ''
+description: "Get a specific simulation by ID."
 openapi: 'GET /v1/simulation/{simulation_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/get-simulations-by-agent.mdx
+++ b/api-reference/endpoint/get-simulations-by-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Simulations by Agent'
-description: ''
+description: "Get all simulations for a specific agent."
 openapi: 'GET /v1/get-simulations-by-agent/{agent_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/list-labels.mdx
+++ b/api-reference/endpoint/list-labels.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'List Labels'
-description: ''
+description: "List all free-standing labels for an agent; filter by substring with q."
 openapi: 'GET /v1/agents/{agent_id}/labels'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/list-prompt-versions.mdx
+++ b/api-reference/endpoint/list-prompt-versions.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'List Prompt Versions'
-description: ''
+description: "List prompt versions with optional filters (label, version)."
 openapi: 'GET /v1/agents/{agent_id}/prompts/versions'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/move-agent-to-folder.mdx
+++ b/api-reference/endpoint/move-agent-to-folder.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Move Agent to Folder'
-description: ''
+description: "Move an agent to a folder or disassociate it from any folder."
 openapi: 'PUT /v1/folders/move-agent'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/phone-numbers.mdx
+++ b/api-reference/endpoint/phone-numbers.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Get Phone Numbers'
-description: ''
+description: "Return phone number under an org."
 openapi: 'GET /v1/phone-numbers'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/promote-prompt.mdx
+++ b/api-reference/endpoint/promote-prompt.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Promote Prompt'
-description: ''
+description: "Move the production label to the latest prompt version, or to the version identified by prompt_id."
 openapi: 'POST /v1/agents/{agent_id}/prompts/promote'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/pull-bluejay-as-code.mdx
+++ b/api-reference/endpoint/pull-bluejay-as-code.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Pull Bluejay as Code"
+description: "Export a Bluejay configuration as a JSON payload, rooted at any of four entity types."
 openapi: "GET /v1/bluejay-as-code/{root_type}/{root_id}"
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/push-bluejay-as-code.mdx
+++ b/api-reference/endpoint/push-bluejay-as-code.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Push Bluejay as Code"
+description: "Apply a Bluejay as Code payload to Bluejay."
 openapi: "POST /v1/bluejay-as-code"
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/queue-http-text-simulation-run.mdx
+++ b/api-reference/endpoint/queue-http-text-simulation-run.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Queue HTTP Text Simulation Run'
-description: ''
+description: "Queue a new simulation run and test results for HTTP text agent. Takes simulation_id, optional prompt_id, knowledge_base_id, and digital_human_ids."
 openapi: 'POST /v1/queue-http-text-simulation-run'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/queue-simulation-run.mdx
+++ b/api-reference/endpoint/queue-simulation-run.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Queue Simulation Run'
-description: ''
+description: "Queue a simulation run for processing."
 openapi: 'POST /v1/queue-simulation-run'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/re-evaluate.mdx
+++ b/api-reference/endpoint/re-evaluate.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Reevaluate'
-description: ''
+description: "Re-evaluate a call."
 openapi: 'POST /v1/re-evaluate/{conversation_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/remove-digital-humans-from-simulation.mdx
+++ b/api-reference/endpoint/remove-digital-humans-from-simulation.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Remove Digital Humans from Simulation'
-description: ''
+description: "Remove digital humans from a simulation (unlink only); idempotent for missing links."
 openapi: 'POST /v1/simulation/{simulation_id}/remove-digital-humans'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/retrieve-call-log.mdx
+++ b/api-reference/endpoint/retrieve-call-log.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Retrieve Call Log'
-description: ''
+description: "Retrieve a single call log by its call ID."
 openapi: 'GET /v1/retrieve-call-log/{call_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/retrieve-call-logs.mdx
+++ b/api-reference/endpoint/retrieve-call-logs.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Retrieve Call Logs'
-description: ''
+description: "Retrieve call logs for a specific agent given the agent ID."
 openapi: 'GET /v1/retrieve-call-logs/{agent_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/retrieve-simulation-result.mdx
+++ b/api-reference/endpoint/retrieve-simulation-result.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Retrieve Simulation Result'
-description: ''
+description: "Retrieve a single test result and its associated custom metrics."
 openapi: 'GET /v1/retrieve-simulation-result/{test_result_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/retrieve-simulation-results.mdx
+++ b/api-reference/endpoint/retrieve-simulation-results.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Retrieve Simulation Results'
-description: ''
+description: "Retrieve the results of a simulation run. Returns the simulation run details and associated test cases."
 openapi: 'GET /v1/retrieve-simulation-results/{simulation_run_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/send-http-text-message.mdx
+++ b/api-reference/endpoint/send-http-text-message.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Send HTTP Text Message'
-description: ''
+description: "Receive a text message via HTTP, process it through the lambda, and send response to webhook."
 openapi: 'POST /v1/send-http-text-message'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/translate-transcript.mdx
+++ b/api-reference/endpoint/translate-transcript.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Translate Transcript'
-description: ''
+description: "Translates all utterances in a simulation or production conversation transcript to the specified target language using Google Translate API."
 openapi: 'POST /v1/translate-transcript'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/update-agent-by-external-id.mdx
+++ b/api-reference/endpoint/update-agent-by-external-id.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Update Agent By External ID'
-description: ''
+description: "Update an existing agent in the system by external ID."
 openapi: 'PUT /v1/update-agent-by-external-id'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/update-agent.mdx
+++ b/api-reference/endpoint/update-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Update Agent'
-description: ''
+description: "Update an existing agent in the system."
 openapi: 'POST /v1/update-agent'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/update-community.mdx
+++ b/api-reference/endpoint/update-community.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Update Community'
-description: ''
+description: "Update a specific community by ID."
 openapi: 'PUT /v1/update-community/{community_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/update-custom-metric.mdx
+++ b/api-reference/endpoint/update-custom-metric.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Update Custom Metric'
-description: ''
+description: "Update a specific custom metric by ID."
 openapi: 'PUT /v1/update-custom-metric/{metric_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/update-customer-persona.mdx
+++ b/api-reference/endpoint/update-customer-persona.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Update Customer Persona'
-description: ''
+description: "Update a specific customer persona by ID."
 openapi: 'PUT /v1/update-customer-persona/{persona_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/update-digital-human.mdx
+++ b/api-reference/endpoint/update-digital-human.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Update Digital Human'
-description: ''
+description: "Update a digital human by ID. Returns 404 if the digital human does not exist or belongs to a different organization."
 openapi: 'PUT /v1/update-digital-human/{digital_human_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/update-folder.mdx
+++ b/api-reference/endpoint/update-folder.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Update Folder'
-description: ''
+description: "Update a folder's name. Returns the updated folder details."
 openapi: 'PUT /v1/update-folder/{folder_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/update-label.mdx
+++ b/api-reference/endpoint/update-label.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Update Label'
-description: ''
+description: "Rename a free-standing label; reserved labels are not allowed as targets."
 openapi: 'PUT /v1/agents/{agent_id}/labels/{label_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/endpoint/update-simulation.mdx
+++ b/api-reference/endpoint/update-simulation.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Update Simulation'
-description: ''
+description: "Update a specific simulation by ID. Only fields provided in the request body will be updated."
 openapi: 'PUT /v1/simulation/{simulation_id}'
 ---
 <div className="ai-prompt-box">

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Introduction'
+title: "API Reference Introduction"
+sidebarTitle: "Introduction"
 description: 'Build with the Bluejay simulations and observability APIs'
 icon: code
 ---

--- a/api-reference/webhook/events-webhook.mdx
+++ b/api-reference/webhook/events-webhook.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Events Webhook'
+description: "Upon an event on the platform, we'll send you the results to the URL you registered within the dashboard."
 openapi: 'WEBHOOK events_webhook'
 ---
 <div className="ai-prompt-box">

--- a/docs.json
+++ b/docs.json
@@ -214,6 +214,198 @@
     {
       "source": "/university/:slug*",
       "destination": "/index"
+    },
+    {
+      "source": "/monitor/overview",
+      "destination": "/monitor/observability/overview"
+    },
+    {
+      "source": "/test/overview",
+      "destination": "/test/simulations/overview"
+    },
+    {
+      "source": "/cookbook/observability",
+      "destination": "/monitor/observability/overview"
+    },
+    {
+      "source": "/v1/get-all-simulations",
+      "destination": "/api-reference/endpoint/get-all-simulations"
+    },
+    {
+      "source": "/v1/create-customer-persona",
+      "destination": "/api-reference/endpoint/create-customer-persona"
+    },
+    {
+      "source": "/v1/create-digital-human",
+      "destination": "/api-reference/endpoint/create-digital-human"
+    },
+    {
+      "source": "/v1/bluejay-as-code",
+      "destination": "/key-concepts/bluejay-as-code/overview"
+    },
+    {
+      "source": "/api-reference/customer-personas/update-customer-persona",
+      "destination": "/api-reference/endpoint/update-customer-persona"
+    },
+    {
+      "source": "/api-reference/folders/get-folder",
+      "destination": "/api-reference/endpoint/get-folder"
+    },
+    {
+      "source": "/api-reference/delete-schedule",
+      "destination": "/api-reference/endpoint/delete-schedule"
+    },
+    {
+      "source": "/v1/end-conversations",
+      "destination": "/api-reference/endpoint/end-conversations"
+    },
+    {
+      "source": "/v1/update-simulation-result",
+      "destination": "/api-reference/endpoint/update-simulation-result"
+    },
+    {
+      "source": "/api-reference/simulations/add-digital-humans-to-simulation",
+      "destination": "/api-reference/endpoint/add-digital-humans-to-simulation"
+    },
+    {
+      "source": "/v1/queue-http-text-simulation-run",
+      "destination": "/api-reference/endpoint/queue-http-text-simulation-run"
+    },
+    {
+      "source": "/v1/evaluate",
+      "destination": "/api-reference/endpoint/evaluate"
+    },
+    {
+      "source": "/api-reference/folders/update-folder",
+      "destination": "/api-reference/endpoint/update-folder"
+    },
+    {
+      "source": "/api-reference/simulations/delete-simulation",
+      "destination": "/api-reference/endpoint/delete-simulation"
+    },
+    {
+      "source": "/api-reference/custom-metrics/create-custom-metrics",
+      "destination": "/api-reference/endpoint/create-custom-metrics"
+    },
+    {
+      "source": "/api-reference/alerts/update-alert",
+      "destination": "/api-reference/endpoint/update-alert"
+    },
+    {
+      "source": "/api-reference/create-schedule",
+      "destination": "/api-reference/endpoint/create-schedule"
+    },
+    {
+      "source": "/v1/queue-simulation-run",
+      "destination": "/api-reference/endpoint/queue-simulation-run"
+    },
+    {
+      "source": "/api-reference/digital-humans/delete-digital-human",
+      "destination": "/api-reference/endpoint/delete-digital-human"
+    },
+    {
+      "source": "/api-reference/agents/delete-agent",
+      "destination": "/api-reference/endpoint/delete-agent"
+    },
+    {
+      "source": "/api-reference/labels/list-labels",
+      "destination": "/api-reference/endpoint/list-labels"
+    },
+    {
+      "source": "/api-reference/generate-digital-humans",
+      "destination": "/api-reference/endpoint/generate-digital-humans"
+    },
+    {
+      "source": "/bluejay-as-code",
+      "destination": "/key-concepts/bluejay-as-code/overview"
+    },
+    {
+      "source": "/api-reference/custom-metrics/delete-custom-metric",
+      "destination": "/api-reference/endpoint/delete-custom-metric"
+    },
+    {
+      "source": "/api-reference/digital-humans/get-digital-human",
+      "destination": "/api-reference/endpoint/get-digital-human"
+    },
+    {
+      "source": "/v1/create-digital-humans",
+      "destination": "/api-reference/endpoint/create-digital-humans"
+    },
+    {
+      "source": "/api-reference/get-simulation-runs",
+      "destination": "/api-reference/endpoint/get-simulation-runs"
+    },
+    {
+      "source": "/api-reference/add-agent",
+      "destination": "/api-reference/endpoint/add-agent"
+    },
+    {
+      "source": "/evaluate",
+      "destination": "/api-reference/endpoint/evaluate"
+    },
+    {
+      "source": "/re-evaluate",
+      "destination": "/api-reference/endpoint/re-evaluate"
+    },
+    {
+      "source": "/api-reference/retrieve-simulation-result",
+      "destination": "/api-reference/endpoint/retrieve-simulation-result"
+    },
+    {
+      "source": "/api-reference/update-schedule",
+      "destination": "/api-reference/endpoint/update-schedule"
+    },
+    {
+      "source": "/api-reference/folders/create-folder",
+      "destination": "/api-reference/endpoint/create-folder"
+    },
+    {
+      "source": "/api-reference/simulations/get-simulation",
+      "destination": "/api-reference/endpoint/get-simulation"
+    },
+    {
+      "source": "/api-reference/get-simulations-by-agent",
+      "destination": "/api-reference/endpoint/get-simulations-by-agent"
+    },
+    {
+      "source": "/v1/create-simulation",
+      "destination": "/api-reference/endpoint/create-simulation"
+    },
+    {
+      "source": "/api-reference/end-conversations",
+      "destination": "/api-reference/endpoint/end-conversations"
+    },
+    {
+      "source": "/api-reference/get-all-simulations",
+      "destination": "/api-reference/endpoint/get-all-simulations"
+    },
+    {
+      "source": "/api-reference/retrieve-simulation-results",
+      "destination": "/api-reference/endpoint/retrieve-simulation-results"
+    },
+    {
+      "source": "/api-reference/agents/get-agent",
+      "destination": "/api-reference/endpoint/get-agent"
+    },
+    {
+      "source": "/api-reference/folders/delete-folder",
+      "destination": "/api-reference/endpoint/delete-folder"
+    },
+    {
+      "source": "/v1/send-http-text-message",
+      "destination": "/api-reference/endpoint/send-http-text-message"
+    },
+    {
+      "source": "/key-concepts/bluejay-as-code/skill.txt",
+      "destination": "/key-concepts/bluejay-as-code/skill"
+    },
+    {
+      "source": "/api-reference/prompts/get-prompt-by-id",
+      "destination": "/api-reference/endpoint/get-prompt-by-id"
+    },
+    {
+      "source": "/api-reference/text-simulations/queue-sms-simulation-run",
+      "destination": "/api-reference/endpoint/queue-sms-simulation-run"
     }
   ],
   "api": {

--- a/fix-docs-seo.py
+++ b/fix-docs-seo.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Redirect the renamed docs URLs and give the API reference real descriptions.
+
+Two things Search Console surfaced on docs.getbluejay.ai:
+
+1. **106 URLs Google still crawls return 404.** The API reference was
+   restructured -- endpoints moved from `/v1/<name>` and
+   `/api-reference/<group>/<name>` to `/api-reference/endpoint/<name>` -- and a
+   handful of guide pages moved too (`/monitor/overview` ->
+   `/monitor/observability/overview`). docs.json already carries 47 redirects,
+   so this appends to an established list.
+
+   48 of the 106 map to a live page by an exact last-segment match, plus six
+   guide pages checked by hand against the folder listing. The remaining 58 are
+   left alone on purpose: 16 are route patterns containing `{param}` or `:slug*`
+   rather than URLs, and 41 name endpoints that no longer exist under any name.
+   Pointing those at the API reference index would be a soft 404, which Google
+   treats worse than the honest 404 they return today.
+
+2. **87 of the 105 API reference pages have no meta description** -- four have
+   no key at all and 83 have `description: ''`. These pages rank (several
+   between positions 3 and 7), so Google is writing their search snippets from
+   whatever it can scrape off a page whose body is mostly a code sample.
+
+   The descriptions are not invented here. Every page carries an authoritative
+   one-liner in its body -- `> **What this endpoint does:** ...` -- written by
+   whoever documented the endpoint. 74 pages have one and it is lifted verbatim,
+   trimmed to a whole sentence within a snippet-sized limit. The 13 without one
+   are left for someone who knows the endpoint.
+
+    python3 fix-docs-seo.py <path-to-docs-repo> --check
+    python3 fix-docs-seo.py <path-to-docs-repo>
+
+Idempotent: existing redirects are not duplicated and a page that already has a
+non-empty description is skipped. Self-verifying: re-reads docs.json and every
+page it touched, and fails non-zero on a duplicate redirect source, a redirect
+whose destination is not a real page, or frontmatter that no longer parses.
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+# Google truncates a snippet around 155-160 characters, so anything past this is
+# invisible in results and only dilutes the useful part.
+DESC_MAX = 155
+WHAT = re.compile(r"\*\*What this (?:endpoint|webhook) does:\*\*\s*(.+)")
+FM = re.compile(r"\A---\n(.*?)\n---\n", re.S)
+
+# Several source lines are raw docstrings that continue into implementation
+# detail -- "Args: test_result_id: the ID of...", "Returns: the test result...",
+# status-code branches like "- if label is missing -> 400". None of that belongs
+# in a search snippet, so the description stops where the prose does.
+TAIL = re.compile(r"\s+(?:Args:|Returns:|Raises:|Params:|Note:|-\s|->)", re.I)
+
+# Guide pages, each checked against the repo's folder listing rather than
+# matched by string similarity -- "overview" appears under several folders.
+MANUAL = {
+    "/monitor/overview": "/monitor/observability/overview",
+    "/test/overview": "/test/simulations/overview",
+    "/cookbook/observability": "/monitor/observability/overview",
+    "/bluejay-as-code": "/key-concepts/bluejay-as-code/overview",
+    "/v1/bluejay-as-code": "/key-concepts/bluejay-as-code/overview",
+    "/key-concepts/bluejay-as-code/skill.txt": "/key-concepts/bluejay-as-code/skill",
+}
+
+
+# One page whose own source line is wrong, so lifting it faithfully would ship a
+# factual error. retrieve-call-log is GET /v1/retrieve-call-log/{call_id} and
+# retrieve-call-logs is GET /v1/retrieve-call-logs/{agent_id}, but both carry the
+# line "Retrieve call logs for a specific agent given the agent ID" -- true only
+# of the plural one. This states what the singular endpoint's own signature says,
+# and removes the only duplicate description in the set. Kept here rather than
+# hand-edited into the file so a re-run does not silently undo it.
+MANUAL_DESC = {
+    "/api-reference/endpoint/retrieve-call-log": "Retrieve a single call log by its call ID.",
+}
+
+
+def page_paths(repo):
+    return {"/" + str(p.relative_to(repo)).replace(".mdx", ""): p
+            for p in repo.rglob("*.mdx") if ".git" not in str(p)}
+
+
+# Two or more "N. " markers means the string really is an enumerated list, and a
+# period after a digit is a marker rather than a full stop. One on its own is a
+# sentence that happens to end in a number ("Supports up to 10. Additional runs
+# are queued"), which must stay two sentences. Case cannot be used to tell them
+# apart here -- these source lines are docstrings written in lower case, so the
+# text after a genuine full stop is lower case too.
+LISTY = re.compile(r"(?:^|\s)\d+\.\s.*(?:^|\s)\d+\.\s")
+
+
+def sentences(text):
+    """Split on sentence ends, without treating a list marker as one."""
+    listy = bool(LISTY.search(text))
+    parts, buf = [], ""
+    for tok in re.split(r"([.!?]+(?:\s|$))", text):
+        if not tok:
+            continue
+        if re.fullmatch(r"[.!?]+(?:\s|$)", tok):
+            if listy and re.search(r"(?:^|\s)\d+$", buf):
+                buf += tok
+                continue
+            parts.append(buf + tok)
+            buf = ""
+        else:
+            buf += tok
+    if buf.strip():
+        parts.append(buf)
+    return parts
+
+
+def snippet(text, limit=DESC_MAX):
+    """A source line turned into something that reads well in a search result."""
+    text = re.sub(r"\s+", " ", text).strip()
+    cut = TAIL.search(text)
+    if cut:
+        text = text[:cut.start()].strip()
+    # Markdown survives into the snippet as literal asterisks and backticks.
+    text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", text)
+    text = text.strip().strip("*").strip()
+    if len(text) > limit:
+        out = ""
+        for s in sentences(text):
+            if out and len(out) + len(s) > limit:
+                break
+            out += s
+        text = (out or text[:limit].rsplit(" ", 1)[0]).strip()
+    if not text:
+        return ""
+    # These lines are docstrings, so most are lower-case throughout -- not just
+    # at the start. Capitalising only the first letter left descriptions reading
+    # "Update a specific simulation by id. only fields provided will be updated."
+    text = "".join(s[0].upper() + s[1:] if s[:1].isalpha() else s for s in sentences(text)) or text
+    # "by id" is the minority spelling here; the sibling pages say "by ID".
+    text = re.sub(r"\bid\b", "ID", text)
+    if not text.endswith((".", "!", "?")):
+        text += "."
+    return text.strip()
+
+
+def build_redirects(repo, dead_file, pages, existing):
+    by_last = {}
+    for path in pages:
+        by_last.setdefault(path.rsplit("/", 1)[-1], []).append(path)
+    new, skipped = [], []
+    for line in pathlib.Path(dead_file).read_text().split("\n"):
+        d = line.strip()
+        if not d or d in existing:
+            continue
+        if d in MANUAL:
+            new.append({"source": d, "destination": MANUAL[d]})
+            continue
+        if "{" in d or ":slug" in d:
+            skipped.append((d, "route pattern, not a URL"))
+            continue
+        hits = by_last.get(d.rsplit("/", 1)[-1], [])
+        if len(hits) == 1:
+            new.append({"source": d, "destination": hits[0]})
+        else:
+            skipped.append((d, "no page with that name" if not hits else f"ambiguous ({len(hits)})"))
+    return new, skipped
+
+
+def fill_descriptions(pages, apply):
+    filled, no_source = 0, []
+    touched = []
+    for path, p in sorted(pages.items()):
+        s = p.read_text(encoding="utf-8")
+        m = FM.match(s)
+        if not m:
+            continue
+        fm = m.group(1)
+        cur = re.search(r"^description:\s*(.*)$", fm, re.M)
+        if cur and cur.group(1).strip().strip("'\""):
+            continue
+        if path in MANUAL_DESC:
+            desc = MANUAL_DESC[path]
+        else:
+            w = WHAT.search(s)
+            if not w:
+                no_source.append(path)
+                continue
+            desc = snippet(w.group(1))
+        if not desc:
+            no_source.append(path)
+            continue
+        # json.dumps gives a double-quoted, correctly escaped scalar. Several of
+        # these lines contain an apostrophe, which would end a single-quoted YAML
+        # value early and leave the frontmatter unparseable.
+        line = f"description: {json.dumps(desc, ensure_ascii=False)}"
+        newfm = (re.sub(r"^description:\s*.*$", line, fm, count=1, flags=re.M)
+                 if cur else re.sub(r"^(title:\s*.*)$", r"\1\n" + line, fm, count=1, flags=re.M))
+        if apply:
+            p.write_text(s[:m.start(1)] + newfm + s[m.end(1):], encoding="utf-8")
+        filled += 1
+        touched.append(p)
+    return filled, no_source, touched
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("repo")
+    ap.add_argument("--dead", default=None, help="file of 404 paths, one per line")
+    ap.add_argument("--check", action="store_true")
+    args = ap.parse_args()
+
+    repo = pathlib.Path(args.repo).resolve()
+    cfg = repo / "docs.json"
+    if not cfg.exists():
+        sys.exit(f"no docs.json under {repo}")
+    doc = json.loads(cfg.read_text(encoding="utf-8"))
+    pages = page_paths(repo)
+    existing = {r["source"] for r in doc.get("redirects", [])}
+
+    new = []
+    skipped = []
+    if args.dead:
+        new, skipped = build_redirects(repo, args.dead, pages, existing)
+
+    filled, no_source, touched = fill_descriptions(pages, apply=not args.check)
+
+    verb = "would add" if args.check else "added"
+    print(f"{verb}: {len(new)} redirects (docs.json had {len(existing)})")
+    print(f"{verb.replace('add','fill')}: {filled} descriptions lifted from each page's own body")
+    if skipped:
+        print(f"left 404ing on purpose: {len(skipped)}")
+    if no_source:
+        print(f"no 'What this endpoint does' line, left alone: {len(no_source)}")
+
+    if args.check:
+        return 0
+
+    if new:
+        doc.setdefault("redirects", []).extend(new)
+        cfg.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    # verify
+    doc2 = json.loads(cfg.read_text(encoding="utf-8"))
+    problems = []
+    srcs = [r["source"] for r in doc2["redirects"]]
+    if len(srcs) != len(set(srcs)):
+        dupes = {s for s in srcs if srcs.count(s) > 1}
+        problems.append(f"duplicate redirect sources: {sorted(dupes)[:4]}")
+    for r in doc2["redirects"]:
+        d = r["destination"]
+        if "{" in d or ":slug" in d or d.startswith("http"):
+            continue
+        if d not in pages:
+            problems.append(f"redirect target is not a page: {r['source']} -> {d}")
+    for p in touched:
+        s = p.read_text(encoding="utf-8")
+        m = FM.match(s)
+        if not m:
+            problems.append(f"{p.name}: frontmatter no longer parses")
+            continue
+        d = re.search(r"^description:\s*(.*)$", m.group(1), re.M)
+        if not d or not d.group(1).strip().strip("'\""):
+            problems.append(f"{p.name}: description still empty")
+
+    print(f"verify: {len(doc2['redirects'])} redirects and {len(touched)} pages checked")
+    if problems:
+        print(f"VERIFY FAILED ({len(problems)}):")
+        for x in problems[:8]:
+            print(f"    {x}")
+        return 1
+    print("verify: no duplicate sources, every target resolves, all frontmatter parses")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fix-docs-titles.py
+++ b/fix-docs-titles.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Disambiguate duplicate page titles without changing the sidebar.
+
+25 pages share a title with at least one other page. Thirteen are called
+"Overview" and four pairs -- Alerts, Dashboards, Tool Calls, Traces -- exist once
+under monitor/observability and again under test/simulations. Mintlify renders
+the frontmatter `title` into `<title>`, so Google currently sees thirteen results
+reading "Overview - Bluejay Docs" and cannot tell them apart. Neither can a
+reader scanning a result list.
+
+The parent folder already says which one it is, so the fix is to put that in the
+title: `key-concepts/agents/overview` becomes "Agents Overview",
+`monitor/observability/alerts` becomes "Observability Alerts".
+
+### Why the sidebar does not change
+
+Mintlify's `sidebarTitle` overrides the navigation label independently of
+`title`. Every page edited here gets `sidebarTitle` set to the label it renders
+today, so the nav tree is byte-identical to what shipped. What does change is the
+page's own `<h1>` and the browser tab, which is the point -- a page whose only
+heading is the word "Overview" tells a reader arriving from search nothing.
+
+    python3 fix-docs-titles.py <path-to-docs-repo> --check
+    python3 fix-docs-titles.py <path-to-docs-repo>
+
+Idempotent: a page that already has a `sidebarTitle` is left alone. Self-
+verifying: re-reads every file and fails non-zero if any title is still
+duplicated, if a sidebarTitle does not match the label that page had before, or
+if frontmatter stops parsing.
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+FM = re.compile(r"\A---\n(.*?)\n---\n", re.S)
+
+# Folder segment -> the word that belongs in the title. Only needed where the
+# folder name alone would read oddly; everything else is title-cased from the
+# path.
+WORDS = {
+    "api-reference": "API Reference",
+    "bluejay-as-code": "Bluejay as Code",
+    "key-concepts": "Key Concepts",
+    "metrics-lab": "Metrics Lab",
+    "red-teaming": "Red Teaming",
+    "digital-humans": "Digital Humans",
+    "custom-metrics": "Custom Metrics",
+    "customer-traits": "Customer Traits",
+    "scenario-builder": "Scenario Builder",
+    "observability": "Observability",
+    "simulations": "Simulation",
+}
+
+
+def humanise(seg):
+    return WORDS.get(seg, seg.replace("-", " ").title())
+
+
+def frontmatter(p):
+    s = p.read_text(encoding="utf-8")
+    m = FM.match(s)
+    return (s, m, m.group(1)) if m else (s, None, None)
+
+
+def field(fm, name):
+    m = re.search(rf"^{name}:\s*(.*)$", fm, re.M)
+    return m.group(1).strip().strip("'\"") if m else None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("repo")
+    ap.add_argument("--check", action="store_true")
+    args = ap.parse_args()
+
+    repo = pathlib.Path(args.repo).resolve()
+    pages = {}
+    for p in sorted(repo.rglob("*.mdx")):
+        if ".git" in str(p):
+            continue
+        s, m, fm = frontmatter(p)
+        if not m:
+            continue
+        pages[p] = (s, m, fm, field(fm, "title") or "")
+
+    counts = {}
+    for _, (_, _, _, t) in pages.items():
+        counts[t] = counts.get(t, 0) + 1
+    dupes = {t for t, c in counts.items() if c > 1 and t}
+
+    changed, before = 0, {}
+    for p, (s, m, fm, title) in pages.items():
+        if title not in dupes:
+            continue
+        if field(fm, "sidebarTitle"):
+            continue
+        parent = p.relative_to(repo).parent.name
+        prefix = humanise(parent)
+        # test/simulations/alerts -> "Simulation Alerts", not "Simulations Alerts";
+        # key-concepts/agents/overview -> "Agents Overview".
+        new_title = title if title.startswith(prefix) else f"{prefix} {title}"
+        if new_title == title:
+            continue
+        before[str(p.relative_to(repo))] = title
+        newfm = re.sub(r"^title:\s*.*$",
+                       f"title: {json.dumps(new_title, ensure_ascii=False)}\n"
+                       f"sidebarTitle: {json.dumps(title, ensure_ascii=False)}",
+                       fm, count=1, flags=re.M)
+        if not args.check:
+            p.write_text(s[:m.start(1)] + newfm + s[m.end(1):], encoding="utf-8")
+        changed += 1
+
+    verb = "would retitle" if args.check else "retitled"
+    print(f"{verb}: {changed} pages ({len(dupes)} titles were shared by more than one page)")
+    for f, t in sorted(before.items())[:6]:
+        print(f"    {f[:52]:<54} {t!r} -> keeps {t!r} in the sidebar")
+    if args.check:
+        return 0
+
+    # verify
+    problems = []
+    seen = {}
+    for p in sorted(repo.rglob("*.mdx")):
+        if ".git" in str(p):
+            continue
+        s, m, fm = frontmatter(p)
+        if not m:
+            problems.append(f"{p.name}: frontmatter no longer parses")
+            continue
+        t = field(fm, "title")
+        rel = str(p.relative_to(repo))
+        if rel in before:
+            sb = field(fm, "sidebarTitle")
+            if sb != before[rel]:
+                problems.append(f"{rel}: sidebarTitle is {sb!r}, sidebar would change (was {before[rel]!r})")
+        seen.setdefault(t, []).append(rel)
+    still = {t: f for t, f in seen.items() if t and len(f) > 1}
+    if still:
+        problems.append(f"titles still duplicated: {list(still)[:4]}")
+
+    print(f"verify: {len(seen)} distinct titles across {sum(len(v) for v in seen.values())} pages")
+    if problems:
+        print(f"VERIFY FAILED ({len(problems)}):")
+        for x in problems[:8]:
+            print(f"    {x}")
+        return 1
+    print("verify: every title is unique, and every sidebar label is unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/key-concepts/agents/overview.mdx
+++ b/key-concepts/agents/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: "Agents Overview"
+sidebarTitle: "Overview"
 description: How Bluejay models Agents and connects them to simulations, observability, custom metrics, and workflows
 icon: robot
 ---

--- a/key-concepts/alerts/overview.mdx
+++ b/key-concepts/alerts/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: "Alerts Overview"
+sidebarTitle: "Overview"
 description: Understand how Alerts are configured and used in Bluejay
 icon: bell
 ---

--- a/key-concepts/communities/overview.mdx
+++ b/key-concepts/communities/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: "Communities Overview"
+sidebarTitle: "Overview"
 description: Understand how Communities are organized and used in Bluejay
 icon: people-group
 ---

--- a/key-concepts/custom-metrics/overview.mdx
+++ b/key-concepts/custom-metrics/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: "Custom Metrics Overview"
+sidebarTitle: "Overview"
 description: Understand how Custom Metrics are defined and used in Bluejay
 icon: gauge-high
 ---

--- a/key-concepts/custom-metrics/prompting-guide.mdx
+++ b/key-concepts/custom-metrics/prompting-guide.mdx
@@ -1,5 +1,6 @@
 ---
-title: Prompting Guide
+title: "Custom Metrics Prompting Guide"
+sidebarTitle: "Prompting Guide"
 description: Best practices for writing Custom Metric prompts that produce reliable, predictable evaluations
 icon: pen-fancy
 ---

--- a/key-concepts/customer-traits/overview.mdx
+++ b/key-concepts/customer-traits/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: "Customer Traits Overview"
+sidebarTitle: "Overview"
 description: Understand how Customer Traits are modeled and used in Bluejay
 icon: id-card
 ---

--- a/key-concepts/dashboards/overview.mdx
+++ b/key-concepts/dashboards/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: "Dashboards Overview"
+sidebarTitle: "Overview"
 description: Understand how Dashboards are used in Bluejay
 icon: table-columns
 ---

--- a/key-concepts/digital-humans/overview.mdx
+++ b/key-concepts/digital-humans/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: "Digital Humans Overview"
+sidebarTitle: "Overview"
 description: Understand what Digital Humans are and how they power realistic agent testing on Bluejay
 icon: users
 ---

--- a/key-concepts/digital-humans/prompting-guide.mdx
+++ b/key-concepts/digital-humans/prompting-guide.mdx
@@ -1,5 +1,6 @@
 ---
-title: Prompting Guide
+title: "Digital Humans Prompting Guide"
+sidebarTitle: "Prompting Guide"
 description: Best practices for writing Digital Human intents and success criteria
 icon: pen-fancy
 ---

--- a/key-concepts/metrics-lab/overview.mdx
+++ b/key-concepts/metrics-lab/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: "Metrics Lab Overview"
+sidebarTitle: "Overview"
 description: Clone your QA engineer's judgment into Bluejay's evaluator with the Metrics Lab, a human in the loop workflow that keeps your AI scoring conversations the way your reviewers would
 icon: flask
 ---

--- a/key-concepts/red-teaming/overview.mdx
+++ b/key-concepts/red-teaming/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: "Red Teaming Overview"
+sidebarTitle: "Overview"
 description: Autonomous adversarial testing that probes your voice and chat agents for security breaches and content harms
 icon: shield-halved
 ---

--- a/key-concepts/scenario-builder/overview.mdx
+++ b/key-concepts/scenario-builder/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: "Scenario Builder Overview"
+sidebarTitle: "Overview"
 description: Author conversation scenarios as path graphs that drive digital humans
 icon: map
 ---

--- a/key-concepts/traces/overview.mdx
+++ b/key-concepts/traces/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Overview"
+title: "Traces Overview"
+sidebarTitle: "Overview"
 description: "Send OpenTelemetry traces to Bluejay for production observability and simulation analysis"
 icon: route
 ---

--- a/monitor/observability/alerts.mdx
+++ b/monitor/observability/alerts.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Alerts'
+title: "Observability Alerts"
+sidebarTitle: "Alerts"
 description: 'Get notified when production metrics cross thresholds that need attention'
 icon: bell
 ---

--- a/monitor/observability/dashboards.mdx
+++ b/monitor/observability/dashboards.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Dashboards'
+title: "Observability Dashboards"
+sidebarTitle: "Dashboards"
 description: 'Monitor production agent performance with observability dashboards'
 icon: table-columns
 ---

--- a/monitor/observability/overview.mdx
+++ b/monitor/observability/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: "Observability Overview"
+sidebarTitle: "Overview"
 description: Understand how observability works in Bluejay
 icon: eye
 ---

--- a/monitor/observability/tool-calls.mdx
+++ b/monitor/observability/tool-calls.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Tool Calls'
+title: "Observability Tool Calls"
+sidebarTitle: "Tool Calls"
 description: 'Include tool call data and metadata when evaluating production calls'
 icon: wrench
 ---

--- a/monitor/observability/traces.mdx
+++ b/monitor/observability/traces.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Traces"
+title: "Observability Traces"
+sidebarTitle: "Traces"
 description: "Link OpenTelemetry traces to production conversation evaluations"
 icon: route
 ---

--- a/test/simulations/alerts.mdx
+++ b/test/simulations/alerts.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Alerts'
+title: "Simulation Alerts"
+sidebarTitle: "Alerts"
 description: 'Get notified when simulation results cross quality thresholds'
 icon: bell
 ---

--- a/test/simulations/dashboards.mdx
+++ b/test/simulations/dashboards.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Dashboards'
+title: "Simulation Dashboards"
+sidebarTitle: "Dashboards"
 description: 'Track simulation performance and compare results across runs'
 icon: table-columns
 ---

--- a/test/simulations/overview.mdx
+++ b/test/simulations/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: "Simulation Overview"
+sidebarTitle: "Overview"
 description: Understand how simulations are used for testing in Bluejay
 icon: flask-vial
 ---

--- a/test/simulations/tool-calls.mdx
+++ b/test/simulations/tool-calls.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Tool Calls'
+title: "Simulation Tool Calls"
+sidebarTitle: "Tool Calls"
 description: 'Enrich simulation evaluations with tool call tracking and custom metadata'
 icon: wrench
 ---

--- a/test/simulations/traces.mdx
+++ b/test/simulations/traces.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Traces"
+title: "Simulation Traces"
+sidebarTitle: "Traces"
 description: "Link OpenTelemetry traces to simulation results"
 icon: route
 ---


### PR DESCRIPTION
* Redirect 48 dead docs URLs and give 74 API pages a real description

Search Console has 106 URLs on docs.getbluejay.ai returning 404. The API reference was restructured -- endpoints moved from /v1/<name> and /api-reference/<group>/<name> to /api-reference/endpoint/<name> -- and a few guide pages moved with it. docs.json already carried 47 redirects, so this appends to an established list rather than introducing a pattern.

48 of the 106 resolve to a live page by exact last-segment match, plus six guide pages checked by hand against the folder listing ("overview" exists under several folders, so string similarity is not safe there). The other 58 are left 404ing deliberately: 16 are route patterns holding {param} or :slug* rather than URLs, and 41 name endpoints that no longer exist under any name. Redirecting those to the API reference index would be a soft 404, which Google treats worse than the honest 404 they return now.

Separately, 87 of the 105 API reference pages had no meta description -- four had no key and 83 had description: ''. Several of these rank between positions 3 and 7, so Google was composing their snippets from a page whose body is mostly a code sample. The text here is not written: every page already carries an authoritative '> **What this endpoint does:** ...' line, and 74 of them are lifted verbatim, trimmed to whole sentences within snippet length. The 13 without such a line are left for someone who knows the endpoint.

Descriptions are emitted as JSON-quoted scalars because several contain an apostrophe, which would terminate a single-quoted YAML value early.

Verified: docs.json parses with 95 redirects and no duplicate sources, every redirect destination resolves to a real .mdx page, and all 74 edited files still have parseable frontmatter. The docs.json diff is a pure append (193 added, 1 changed) -- no reformatting.

* QA pass: keep descriptions inside snippet length and free of docstring artefacts

Reviewing the 74 descriptions against snippet criteria surfaced four problems, all in how the source line was lifted rather than in the source itself.

Nine ran past 160 characters, where Google truncates -- the cap was 200. It is 155 now, cut at a sentence boundary.

Several source lines are raw docstrings that continue past the prose into implementation detail: 'Args: test_result_id: the ID of...', 'Returns: the test result...', status branches like '- if label is missing -> 400'. That is not a search snippet. The description now stops where the prose does.

Markdown survived into the frontmatter as literal characters -- '**DEPRECATED**' and backticked identifiers would have rendered as asterisks and backticks in a result. Bold, code spans and links are unwrapped to their text.

Three lines started lower-case and three ended with no terminal punctuation, both of which read as a broken sentence in a result. First letter is capitalised and a period is added when the sentence lacks one.

Also corrects a factual error the lift inherited. retrieve-call-log and retrieve-call-logs are different endpoints -- GET /v1/retrieve-call-log/{call_id} and GET /v1/retrieve-call-logs/{agent_id} -- but both source lines read 'Retrieve call logs for a specific agent given the agent ID', which is wrong for the singular one. Its description now matches its own signature. That also removes the only duplicate description in the set.

After this pass, across all 74: longest is 153 characters, none lack terminal punctuation, none start lower-case, none carry markdown or docstring artefacts, and all 74 are unique.

* Second QA pass: sentence-case throughout, and don't split on list markers

Two more from cubic, both real.

Capitalising only the first letter left later sentences lower-case, because these source lines are docstrings written in lower case throughout -- one read 'Update a specific simulation by id. only fields provided in the request body will be updated.' Every sentence is now capitalised, and 'id' is normalised to 'ID' to match the spelling the sibling pages already use.

snippet() treated the '1.' in a numbered list as a sentence end, so a source line like 'This endpoint: 1. validates the payload 2. queues the run' would have been cut to 'This endpoint: 1.' No page hits this today, but the script is committed and re-runnable, so the splitter now ignores a period that follows a bare digit. That also stops '99.9% uptime' being read as two sentences.

The retrieve-call-log correction moves from a hand edit into MANUAL_DESC. It was lost the first time the descriptions were regenerated, which is exactly the failure mode of fixing generated output by hand.

Re-verified across all 74 after regenerating from the pre-change state: longest 153 characters, none over 160, no lower-case sentence starts anywhere in the string, none missing terminal punctuation, no markdown or docstring artefacts, and no duplicates.

* Disambiguate 24 duplicate page titles, leaving the sidebar untouched

Twenty-five pages shared a title with at least one other. Thirteen were called "Overview"; four pairs -- Alerts, Dashboards, Tool Calls, Traces -- existed once under monitor/observability and again under test/simulations. Mintlify renders the frontmatter title into <title>, so Google was serving thirteen results all reading "Overview - Bluejay Docs", verified live. A reader scanning results cannot tell them apart, and neither can a ranking system.

The parent folder already names the subject, so it moves into the title: key-concepts/agents/overview becomes "Agents Overview", monitor/observability/alerts becomes "Observability Alerts", test/simulations/alerts becomes "Simulation Alerts".

The sidebar does not change. Mintlify's sidebarTitle overrides the navigation label independently of title, so every edited page now carries sidebarTitle set to the exact label it rendered before -- the nav tree is identical to what shipped. What does change is each page's own h1 and browser tab, which is the point: a page whose only heading is the word "Overview" tells a reader arriving from search nothing about what they landed on.

index.mdx keeps "Introduction" -- once api-reference/introduction becomes "API Reference Introduction" there is no collision left to resolve, and the docs home page is where that title belongs.

Verified after applying: 186 distinct titles across 186 pages, no duplicates left, every sidebarTitle equal to that page's previous label, and all frontmatter still parses.

* Only treat a digit-period as a list marker when the string is actually a list

cubic: a description legitimately ending a sentence with a bare integer had its period read as a list marker, merging it with the next sentence -- 'Supports up to 10. Additional runs are queued' became one sentence.

The first attempt keyed on whether the next character was lower case, which does not work here: these source lines are docstrings written in lower case throughout, so the text after a genuine full stop is lower case too.

It now decides once per string. Two or more 'N. ' markers means the string really is an enumerated list and a period after a digit is a marker; a single one is a sentence that happens to end in a number. Decimals were never affected -- '99.9%' has no space after the period, so it was never a split candidate.

No description in the repo hits this today; the script is committed and re-runnable, which is the reason to fix it.

Covered by cases: a real 1./2./3. list stays joined, 'Supports up to 10. Additional runs are queued' stays two sentences, '99.9% uptime. See the status page' stays two, and 'See step 2. The run then queues' -- a single marker -- is correctly two.

Regenerated all descriptions and titles from the pre-change state afterwards: 98 files touched, none of the 74 generated descriptions over 160 characters, no lower-case sentence starts, no markdown or docstring artefacts, no duplicates, 186 unique titles across 186 pages, 95 redirects with no duplicate sources.

---------

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves docs SEO by redirecting legacy URLs, adding meta descriptions to API pages, and retitling duplicate pages so search results are clear and useful. Previously, many old URLs returned 404 and API pages had empty descriptions; now redirects point to live content, 74 endpoints have concise descriptions, and 24 pages have distinct titles without changing sidebar labels.

- Redirects: Append-only updates to docs.json with 48 new redirects (plus a few manual guide moves), leaving route-pattern and retired endpoints as honest 404s (avoids soft-404). Targets resolve to real `.mdx` pages; total redirects now 95.
- API descriptions: Add descriptions to 74 endpoints, lifted from each page’s “What this endpoint does” line, trimmed to ≤155 chars, sentence-cased, punctuation added, and Markdown stripped. Fix a wrong description for `retrieve-call-log`. Descriptions are JSON-quoted in frontmatter.
- Titles: Retitle 24 pages to include context (e.g., “Agents Overview”, “Observability Alerts”), while preserving navigation via `sidebarTitle`. `api-reference/introduction.mdx` becomes “API Reference Introduction”.
- Scripts: Add `fix-docs-seo.py` and `fix-docs-titles.py` to regenerate and verify changes; run with `--check` to validate redirects, targets, and frontmatter.

<sup>Written for commit f5ed99b99481d5270ad04a5a3c522d87bcd192ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

