### PR TITLE
docs(digital-humans): ordered scripted responses

### DIFF
--- a/key-concepts/digital-humans/configuration.mdx
+++ b/key-concepts/digital-humans/configuration.mdx
@@ -90,6 +90,14 @@ Configure a Digital Human to provide **specific responses depending on what your
   </Step>
 </Steps>
 
+#### Any order vs. in order
+
+By default scripted responses are independent rules: any of them fires whenever the agent says its trigger, as often as its occurrence setting allows.
+
+Switch the editor to **In order** to run them as a script. The Digital Human works through the steps top to bottom, one at a time: only the next unfired step is armed, it fires when its trigger comes up, then the following step arms. A step can also fire **on its next turn**, whatever the agent says, which is how you give the Digital Human a fixed sequence of lines or key presses. Each step fires once. After the last step the Digital Human carries on as its persona. Drag the step numbers to reorder.
+
+Use in-order scripts for IVR walk-throughs and regression scripts where the same prompt can come up more than once and the reply has to depend on where you are in the flow.
+
 ### DTMF Codes
 
 Digital Humans can **send DTMF (touch-tone) codes** during a call. This is critical for testing agents that require keypad input, such as entering an account number, selecting a menu option, or confirming a PIN.

--- a/key-concepts/digital-humans/csv-upload.mdx
+++ b/key-concepts/digital-humans/csv-upload.mdx
@@ -61,6 +61,7 @@ There are four kinds of columns: **core fields**, **behavior fields**, **tool ca
 | `Success Criteria` | How the run is judged | Free text: the conditions that must be met to pass. |
 | `Role Description` | Persona background | Free text: who the caller is. |
 | `Scripted Responses` | Deterministic replies | JSON. See [Scripted Responses](#scripted-responses). |
+| `Scripted Responses In Order` | Run the scripted responses as a script | `true` or `false` (default). See [In order](#in-order). |
 
 ### Behavior columns
 
@@ -110,7 +111,7 @@ Make a Digital Human reply deterministically when your agent says (or means) som
 
 | Field | Required | Accepted values | Meaning |
 |---|---|---|---|
-| `match_phrase` | ✅ | string | The agent utterance (or context) that triggers the response. |
+| `match_phrase` | ✅ | string | The agent utterance (or context) that triggers the response. May be blank (`""`) only when `Scripted Responses In Order` is `true`: that step fires on the Digital Human's next turn. |
 | `match_type` | Optional | `exact`, `context` | `exact` is a literal utterance match; `context` is a semantic match. Defaults to `exact`. |
 | `response_type` | Optional | `phrase`, `dtmf`, `silence` | What the Digital Human does when matched. Defaults to `phrase`. |
 | `response_value` | Optional | string | For `phrase`: the words to say. For `dtmf`: comma-separated digits, e.g. `1,2,3,4`. For `silence`: optional words to say *after* the pause. |
@@ -142,6 +143,29 @@ Make a Digital Human reply deterministically when your agent says (or means) som
 <Note>
   Audio scripted responses (playing an uploaded clip) can't be attached through a CSV because there's no file to reference. Add those in the scripted-responses editor after import.
 </Note>
+
+#### In order
+
+Set `Scripted Responses In Order` to `true` to run the array as a script instead of a set of independent rules: the Digital Human works through it top to bottom, one step at a time. Only the next unfired step is armed. It fires when its `match_phrase` comes up, or on the Digital Human's very next turn when `match_phrase` is blank, then the following step arms. Each step fires once; `occurrence_mode` is ignored. After the last step the Digital Human carries on as its persona.
+
+```json Example: a two-step script (Scripted Responses In Order = true)
+[
+  {
+    "match_type": "context",
+    "match_phrase": "",
+    "response_type": "phrase",
+    "response_value": "Hi, I'm calling about my policy.",
+    "occurrence_mode": "always"
+  },
+  {
+    "match_type": "exact",
+    "match_phrase": "Please enter your PIN",
+    "response_type": "dtmf",
+    "response_value": "1,2,3,4",
+    "occurrence_mode": "always"
+  }
+]
+```
 
 ### Interruptions
 

--- a/key-concepts/digital-humans/csv-upload.mdx
+++ b/key-concepts/digital-humans/csv-upload.mdx
@@ -151,21 +151,20 @@ Set `Scripted Responses In Order` to `true` to run the array as a script instead
 ```json Example: a two-step script (Scripted Responses In Order = true)
 [
   {
-    "match_type": "context",
     "match_phrase": "",
     "response_type": "phrase",
-    "response_value": "Hi, I'm calling about my policy.",
-    "occurrence_mode": "always"
+    "response_value": "Hi, I'm calling about my policy."
   },
   {
     "match_type": "exact",
     "match_phrase": "Please enter your PIN",
     "response_type": "dtmf",
-    "response_value": "1,2,3,4",
-    "occurrence_mode": "always"
+    "response_value": "1,2,3,4"
   }
 ]
 ```
+
+The blank first step needs no `match_type` (it fires on the next turn whatever the agent says) and neither step needs `occurrence_mode` (ignored in this mode; both default when omitted).
 
 ### Interruptions
 


### PR DESCRIPTION
## Summary
Documents the new **In order** mode for scripted responses (mdw bluejay-ai-dev/bluejay_middleware#1322, livekit bluejay-ai-dev/livekit_agent#766, FE PR to follow) on the configuration page, plus the `Scripted Responses In Order` CSV column and the blank-trigger step on the CSV upload page.

Merge after the product PRs ship (docs deploy from main).

## Test plan
- [ ] Preview renders both new sections; anchors `#in-order` resolve

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the new In order mode for scripted responses and adds the `Scripted Responses In Order` CSV flag, enabling sequential scripts instead of independent rules. Old: any step could fire whenever its trigger matched. New: only the next unfired step arms and fires once; blank `match_phrase` fires on the Digital Human’s next turn; `occurrence_mode` is ignored in this mode; after the last step the persona resumes; steps are reorderable. The CSV section cross-links to “In order” and includes a trimmed example with only required fields.

**Rollout**
- Merge after the middleware and agent changes ship; docs deploy from main.
- No migration. Default remains independent rules (`Scripted Responses In Order` = `false`).

<sup>Written for commit d908e853950ed333e8dff2e1c262db5b317115e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

