### PR TITLE
docs(changelog): backfill June 24 – August 18 feature entries

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,336 @@ icon: clock
 rss: true
 ---
 
+<Update label="August 18th, 2026" tags={["New", "Observability"]}>
+  ## Issues & Topics (early access)
+
+  Bluejay now clusters what's happening across your production calls automatically. The **Topics** map is an interactive view of what your callers talked about — pan, zoom, search, and see trends against the prior window. The **Issues** screen groups recurring call failures into named clusters, each with a summary, a calls-over-time chart, and sample conversations, so a hundred failing calls collapse into a handful of actionable problems. Rolling out to select organizations first — contact us for access.
+
+  [Observability overview](/monitor/observability/overview)
+</Update>
+
+<Update label="August 18th, 2026" tags={["Improvement", "Digital Humans"]}>
+  ## Expanded language coverage
+
+  Digital humans picked up a wave of new languages and dialects this summer: Urdu, Hebrew, Tagalog, Telugu, Tamil, Malayalam, Kannada, Marathi, and Gujarati, plus Egyptian and Levantine Arabic with native dialect voices. Vietnamese and Cantonese voice coverage was also filled out, and every non-English language received dialect-aware prompting for more authentic speech.
+
+  [Digital humans overview](/key-concepts/digital-humans/overview)
+</Update>
+
+<Update label="August 11th, 2026" tags={["New", "Simulations"]}>
+  ## Custom SIP headers
+
+  Simulations can now attach custom SIP headers to the calls they place. Headers configured on the agent are delivered on the SIP INVITE, so agents behind infrastructure that routes or authenticates on custom headers can be tested exactly as they run in production.
+
+  [SIP connections](/simulation-integrations/sip)
+</Update>
+
+<Update label="August 11th, 2026" tags={["New", "Metrics"]}>
+  ## Custom metrics judged on call audio
+
+  Audio custom metrics are now judged natively on the call recording by an audio-capable model, with optional knowledge-base grounding. Tone, pacing, pronunciation, and other things a transcript can't capture are now first-class evaluation targets.
+
+  [Custom metrics overview](/key-concepts/custom-metrics/overview)
+</Update>
+
+<Update label="August 11th, 2026" tags={["New", "Metrics"]}>
+  ## Outbound call-outcome metrics & spoken-phrase checks
+
+  Eight new library metrics for outbound calling: LLM-judged outcomes (human picked up, voicemail detected, transfer attempted, stuck call, abrupt termination, natural delivery) plus deterministic required-disclosure and prohibited-wording checks. Phrase metrics are authored by simply typing the words the agent must (or must not) say — Bluejay compiles the matching and absorbs ASR variance like punctuation and acronym spellings automatically.
+
+  [Metric types](/key-concepts/custom-metrics/metric-types)
+</Update>
+
+<Update label="August 11th, 2026" tags={["New", "Integration"]}>
+  ## Twilio account linking
+
+  Link your own Twilio account from Settings → Integrations, so simulations can dial using your Twilio numbers.
+</Update>
+
+<Update label="August 11th, 2026" tags={["Improvement", "Integration"]}>
+  ## Pipecat improvements
+
+  Bluejay's Pipecat Cloud integration now sends the run's metadata in the start-call body, so your Pipecat agent can identify and branch on the Bluejay test run that's calling it. Sessions also end cleanly when the agent hangs up or fails to start, instead of waiting for a timeout.
+
+  [Pipecat simulations](/simulation-integrations/pipecat)
+</Update>
+
+<Update label="August 11th, 2026" tags={["Improvement", "Billing"]}>
+  ## Spend breakdown in credits
+
+  The Spend page now breaks your usage down per product, denominated in credits, and the usage page breaks credit consumption down by agent and by individual simulation — including observability-only agents.
+</Update>
+
+<Update label="August 4th, 2026" tags={["New", "Integration"]}>
+  ## Bland integration
+
+  Bland is now a fully supported provider. Connect from Create Agent with inline API key setup, pick a Conversational Pathway, and pull, edit, push, and publish pathway versions from an interactive canvas inside Bluejay. Simulations run over Bland's native voice bridge (with PSTN dialing also supported) and record the exact path each call took through the pathway graph, and Bland production calls can be ingested into observability.
+
+  [Bland Observability](/integrations/bland) · [Bland Simulations](/simulation-integrations/bland)
+</Update>
+
+<Update label="August 4th, 2026" tags={["New", "Observability"]}>
+  ## Natural-language log filtering
+
+  Filter your call logs by just typing. Plain-English queries are translated into structured log filters automatically, on top of the freeform full-text search over call summaries that shipped earlier in July.
+
+  [Observability overview](/monitor/observability/overview)
+</Update>
+
+<Update label="August 4th, 2026" tags={["Improvement", "Platform"]}>
+  ## Knowledge bases: URL & HTML ingestion
+
+  Knowledge bases now accept web pages directly by URL — Bluejay crawls and ingests the page server-side — as well as uploaded HTML files, alongside the existing document upload flow.
+</Update>
+
+<Update label="July 28th, 2026" tags={["New", "Integration"]}>
+  ## Amelia integration
+
+  Test Amelia agents on Bluejay over both chat and voice. Enter your Amelia credentials in Settings → Integrations, pick a domain and flow, and sync agents into Bluejay. You can view and edit the agent's flow on an interactive canvas and push changes back to Amelia.
+
+  [Amelia integration](/integrations/amelia)
+</Update>
+
+<Update label="July 28th, 2026" tags={["New", "Reports"]}>
+  ## Deep Reports
+
+  Agent-generated, verified reports built from your simulation and observability data. A report studio lets you edit the report through chat on a Bluejay-native canvas, schedule recurring sends, and email the result — with PDF export for run comparisons.
+</Update>
+
+<Update label="July 28th, 2026" tags={["New", "Dashboards"]}>
+  ## Dashboard widgets: histograms, filters, and 32 new metrics
+
+  A major dashboard upgrade: a histogram widget for numeric metric distributions, 32 newly graphable metrics in the widget dialogs, distribution aggregation for integer-scale custom metrics, per-widget conversation filters, metadata Group By, and click-a-threshold-bar to filter the explorer to that group. The Logs page also gained a Table | Chart toggle to chart whatever view you've filtered to.
+
+  [Dashboards](/key-concepts/dashboards/overview)
+</Update>
+
+<Update label="July 28th, 2026" tags={["New", "Metrics"]}>
+  ## Answer Latency
+
+  Every simulated call now measures how long the agent took to answer, across all transports. Answer Latency shows up in the conversation Evals tab and as a sortable column in simulation run results, so slow pickup is a trackable signal.
+</Update>
+
+<Update label="July 28th, 2026" tags={["New", "Metrics"]}>
+  ## Human review overrides
+
+  Reviewers can override an automated metric verdict by hand. The human correction is stored alongside the original AI grade — both are preserved — and corrected values show up everywhere: tables, aggregates, and reports.
+
+  [Custom metrics overview](/key-concepts/custom-metrics/overview)
+</Update>
+
+<Update label="July 28th, 2026" tags={["New", "Integration"]}>
+  ## Bluejay in Slack
+
+  Ask Bluejay about your agents, simulations, and production conversations directly from Slack. The per-org Slack bot supports threaded follow-ups without re-tagging, works in externally shared channels, and performs write actions safely via one-click approval messages.
+
+  [Slack integration](/integrations/slack)
+</Update>
+
+<Update label="July 28th, 2026" tags={["New", "Simulations"]}>
+  ## Outbound trigger webhook
+
+  For agents that dial out from your own system, configure a trigger webhook in agent settings: Bluejay calls it to tell your infrastructure to place the call (or send the SMS) to the digital human. Works with any provider, so outbound agents are testable without Bluejay controlling the dialer.
+</Update>
+
+<Update label="July 28th, 2026" tags={["New", "Simulations"]}>
+  ## Extension dialing (DTMF)
+
+  Digital humans can now dial a configured extension as DTMF tones after connecting, so agents behind IVR menus and extension routing can be tested end to end. Extensions can be set per digital human (including in bulk) and on red-team launches.
+</Update>
+
+<Update label="July 28th, 2026" tags={["Improvement", "Integration"]}>
+  ## Google Cloud: selective sync & keyless setup
+
+  Choose exactly which Google Conversational Agents to sync (or toggle sync-all), and connect your Google Cloud project without service-account keys using least-privilege Workload Identity Federation, configured from the settings UI with a paste-and-run Cloud Shell flow.
+
+  [Keyless Google Cloud setup](/integrations/google-cloud-workload-identity)
+</Update>
+
+<Update label="July 28th, 2026" tags={["Improvement", "Metrics"]}>
+  ## Grounded, customizable judging
+
+  LLM-judge custom metrics can now ground their evaluation in your knowledge base, so factual-accuracy metrics grade against your actual documentation. Standard hallucination and redundancy metrics accept per-org prompt overrides and are editable like custom metrics, and new default eval models improve text and audio judging quality.
+
+  [Prompting guide](/key-concepts/custom-metrics/prompting-guide)
+</Update>
+
+<Update label="July 28th, 2026" tags={["Improvement", "Digital Humans"]}>
+  ## Digital human management upgrades
+
+  A table view of digital humans with inline per-field editing, per-digital-human run history pages, duplicate-to-a-target-count, and two new generation sources: build digital humans from your knowledge base's topics, or derive traits from your agent's template variables so provider call variables are filled with each persona's data.
+
+  [Digital humans overview](/key-concepts/digital-humans/overview)
+</Update>
+
+<Update label="July 28th, 2026" tags={["New", "Observability"]}>
+  ## Trace view v2 with token costs
+
+  A redesigned trace experience: per-leg latency dashboards, a rebuilt trace side panel with a standalone full view, and trace export alongside simulation results. Model spans now show token usage (input/cached/output, text/audio splits) with estimated cost per model and trace-level totals. ElevenLabs agent traces are ingested via OpenTelemetry, so their tool calls and spans appear like any other provider's.
+
+  [Traces](/key-concepts/traces/overview)
+</Update>
+
+<Update label="July 21st, 2026" tags={["New", "Platform"]}>
+  ## Self-serve signup
+
+  Bluejay is open to self-serve signups. Sign up with email verification, land in a redesigned onboarding flow with Bluejay AI as your first experience, and start testing immediately against seeded sample agents — including read-only "Bug Bounty" challenge agents built to be probed.
+
+  [Quickstart](/quickstart)
+</Update>
+
+<Update label="July 21st, 2026" tags={["New", "Metrics"]}>
+  ## Metrics Library
+
+  An app-store-style library at /metrics: browse standard and community-published metric templates, preview them, rate them, and add them to your org in one click. You can publish your own metrics to the library through a review queue, and My Metrics was restructured to match.
+
+  [Custom metrics overview](/key-concepts/custom-metrics/overview)
+</Update>
+
+<Update label="July 21st, 2026" tags={["New", "Simulations"]}>
+  ## Red teaming revamp
+
+  A rebuilt red-team experience: a dedicated launch flow and results page with an OWASP/ATLAS-mapped scorecard and leak table, opt-in content-safety attacks as a distinct attack category, audio-native attacker behaviors, keypad (DTMF) attacks, and extension support for targets behind IVRs.
+
+  [Red teaming](/key-concepts/red-teaming/overview) · [Content safety](/key-concepts/red-teaming/content-safety)
+</Update>
+
+<Update label="July 21st, 2026" tags={["New", "Simulations"]}>
+  ## Import workflow diagrams & IVR test plans
+
+  Drop a workflow diagram (for example an IVR flowchart image) into Bluejay AI and it becomes an editable Agent Workflow with a generated checklist-style test plan covering the flow's paths. Step-based IVR test-plan exports import too: Bluejay turns them into transcript-replay digital humans, so existing IVR test scripts become runnable simulations.
+
+  [Agent workflows](/key-concepts/agents/workflow)
+</Update>
+
+<Update label="July 21st, 2026" tags={["New", "Metrics"]}>
+  ## Audio Clarity Score
+
+  A single 0–100 audio clarity score on every call, replacing the earlier burst-SNR approach. The agent channel is scored for intelligibility and the caller channel with DNSMOS, calibrated against a human-labeled gold set, so brief bad stretches aren't averaged away.
+</Update>
+
+<Update label="July 21st, 2026" tags={["New", "Simulations"]}>
+  ## Multimodal journeys & follow-up SMS
+
+  Customer journeys can now mix voice and SMS — for example an SMS leg that ends when the call leg starts — with per-step success criteria and transition guards. Follow-up SMS gets full configuration: call association, a sender allowlist on the Phone Numbers page, and a per-simulation SMS inactivity timeout.
+
+  [Customer journeys](/test/simulations/customer-journeys) · [Follow-up SMS](/key-concepts/digital-humans/follow-up-sms)
+</Update>
+
+<Update label="July 21st, 2026" tags={["Improvement", "Simulations"]}>
+  ## Smarter call endings
+
+  Whether a simulated call should end is now decided by a consensus of judges, with a transfer-intent classifier gating hangups on transfer — so digital humans stop hanging up prematurely on ambiguous turns. Chat simulations gained the same discipline: conversations no longer end while the agent's question is still pending.
+</Update>
+
+<Update label="July 14th, 2026" tags={["New", "Billing"]}>
+  ## Pay-as-you-go, auto-reload & plan limits
+
+  New orgs are provisioned straight onto pay-as-you-go with billing attached at signup, with an optional automatic credit top-up and a wallet-balance view. The billing tab was redesigned with new plan cards, credit codes are redeemable, plan switches reuse your saved card, and unused base allotment rolls over as credit. Plan entitlements — phone number counts, simulation concurrency, data retention — are now enforced in real time.
+</Update>
+
+<Update label="July 14th, 2026" tags={["New", "Platform"]}>
+  ## Unified knowledge bases (RAG)
+
+  Knowledge bases became a full retrieval feature: upload documents, watch ingestion status, and attach knowledge bases to agents. Knowledge you upload once now grounds digital-human behavior, chat simulations, and metric judging consistently everywhere.
+</Update>
+
+<Update label="July 14th, 2026" tags={["Improvement", "Platform"]}>
+  ## Phone number management
+
+  Buy phone numbers in bulk in a single purchase, with limits driven by your plan instead of a hardcoded cap, and a per-number SMS Enabled indicator so you know which numbers can run SMS tests.
+</Update>
+
+<Update label="July 7th, 2026" tags={["New", "Observability"]}>
+  ## Uptime Monitoring
+
+  Continuous health checks for production agents: Bluejay periodically places real calls (or SMS/webchat sessions) against your agent, detects incidents, and alerts on failures — Slack with optional @channel, a configurable consecutive-failure threshold, and latency tracking with 7-day aggregates. Health checks can run full conversations with your own digital human, grade with your custom metrics, respect day/hour active windows, and be paused and resumed.
+
+  [Uptime monitoring](/monitor/uptime/overview)
+</Update>
+
+<Update label="July 7th, 2026" tags={["New", "Platform"]}>
+  ## Voice Agent Audit
+
+  A free public audit: enter your agent's phone number on the landing page and Bluejay runs ~20 tailored test calls with custom metrics and audio-quality checks, then emails you an exec-readable PDF report of the findings.
+</Update>
+
+<Update label="July 7th, 2026" tags={["New", "Integration"]}>
+  ## Custom telephony connections
+
+  For orgs with their own telephony: Bluejay can call a webhook you host at dial time to fetch a per-call SIP endpoint (dynamic routing, ephemeral endpoints), LiveKit agents can authenticate via API key or a token webhook, and outbound simulations can admit authenticated inbound SIP — so setups where your infrastructure originates or routes the call are fully testable.
+
+  [Dynamic SIP webhook](/simulation-integrations/dynamic-sip-webhook)
+</Update>
+
+<Update label="July 7th, 2026" tags={["Improvement", "Simulations"]}>
+  ## No-answer diagnostics
+
+  Calls your agent never answers are now diagnosable: no-answer results carry the recording and the caller-side transcript so you can hear exactly what happened, and dial timeouts are classified correctly instead of as generic failures.
+</Update>
+
+<Update label="June 30th, 2026" tags={["New", "Metrics"]}>
+  ## Tool Call metric & tool adherence
+
+  A new tool_call metric type deterministically checks whether the agent called the right tools — pick tool names from a combobox, no LLM prompt needed. Tool adherence supports expected tool calls with parameter comparison and an order-enforcement toggle, and grading waits for the expected tools' traces to arrive before scoring.
+
+  [Tool calls](/test/simulations/tool-calls)
+</Update>
+
+<Update label="June 30th, 2026" tags={["New", "Integration"]}>
+  ## Vapi squads & Retell conversation flows
+
+  Multi-assistant Vapi squads render as editable workflow canvases, Retell conversation flows get a dedicated editor, and auto-sync keeps Retell, Vapi, and ElevenLabs agents current — with an org-level toggle controlling re-sync before every simulation.
+
+  [Vapi simulations](/simulation-integrations/vapi) · [Retell integration](/integrations/retell)
+</Update>
+
+<Update label="June 30th, 2026" tags={["New", "Platform"]}>
+  ## Self-improve for Vapi agents
+
+  Bluejay can close the test-fix-retest loop for Vapi agents: it analyzes failed results, proposes prompt improvements, applies them, and announces runs when they finish.
+
+  [Self-improve](/key-concepts/self-improve/overview)
+</Update>
+
+<Update label="June 30th, 2026" tags={["New", "Alerts"]}>
+  ## Usage alerts
+
+  Get notified when your org crosses credit-usage thresholds, framed by credits remaining. Every org is seeded with default alerts at 80% and 100% of its allotment, with recipient selection including your whole team.
+
+  [Alerts overview](/key-concepts/alerts/overview)
+</Update>
+
+<Update label="June 30th, 2026" tags={["New", "Digital Humans"]}>
+  ## Voice scenes
+
+  Describe a voice as a scene — "tired commuter on a train" — and Bluejay generates a matching custom voice with bundled background ambience, giving digital humans situationally realistic audio.
+
+  [Digital humans overview](/key-concepts/digital-humans/overview)
+</Update>
+
+<Update label="June 30th, 2026" tags={["New", "Simulations"]}>
+  ## Cross-agent run comparison
+
+  Compare simulation runs across different agents: stage runs into a comparison tray that persists as you browse, then open a side-by-side comparison — with PDF export and instant email send.
+
+  [Simulation runs](/test/simulations/simulation-runs)
+</Update>
+
+<Update label="June 30th, 2026" tags={["Improvement", "Simulations"]}>
+  ## Simulation run controls
+
+  Finer control over how simulations run: a delay-between-tests setting, concurrency capped to your phone-number pool and org ceiling, an org-level max call length with per-simulation override, a per-simulation inactivity timeout, and scheduling restricted to chosen days and hours.
+</Update>
+
+<Update label="June 30th, 2026" tags={["Improvement", "Integration"]}>
+  ## CHIRP playback acknowledgments
+
+  The CHIRP websocket protocol gained a mark message: agents integrating over CHIRP receive playback acknowledgments confirming when queued audio has actually been played to the caller, enabling precise turn-taking and barge-in handling.
+
+  [Websocket connections](/simulation-integrations/websockets)
+</Update>
+
 <Update label="June 23rd, 2026" tags={["New", "Integration"]}>
   ## Google Dialogflow CX integration
 


### PR DESCRIPTION
Changelog was last updated June 23. This backfills every user-facing feature shipped since, aggregated from merge history across bluejay_frontend_v2, bluejay_middleware, livekit_agent, evals, and text_agent.

**30 consolidated entries across 8 weekly labels (June 30 → August 18):**

- **Integrations:** Bland (pathways pull/edit/push + native voice bridge + obs ingestion), Amelia (chat + voice, flow canvas), Twilio account linking, Vapi squads & Retell conversation flows, Google Cloud selective sync + keyless WIF, custom telephony (dynamic SIP webhook, LiveKit token webhook), custom SIP headers, Pipecat improvements, CHIRP mark acks, Bluejay in Slack
- **Metrics:** Tool Call metric & adherence, Audio Clarity Score, audio-judged custom metrics, outbound call-outcome + spoken-phrase metrics, Answer Latency, human review overrides, Metrics Library, KB-grounded judging
- **Simulations:** multimodal journeys + follow-up SMS, DTMF extension dialing, outbound trigger webhook, red teaming revamp, workflow-diagram & IVR test-plan import, run controls, smarter call endings, no-answer diagnostics, cross-agent run comparison
- **Observability:** Uptime Monitoring, trace view v2 + token costs, NL log filtering, Issues & Topics (early access), dashboard widget upgrades
- **Platform/Billing:** self-serve signup, Voice Agent Audit, unified knowledge bases + URL/HTML ingestion, PAYG/auto-reload/plan limits, spend breakdown, phone number management, voice scenes, language expansion, self-improve, usage alerts, DH management

Entry dates = dev-merge week, labeled on the same weekly-Tuesday cadence as existing entries. Reverted-and-relanded features dated at re-land. Flag-gated Issues & Topics marked early access. Internal-only work (CDC migration, Metronome plumbing, admin dashboards, abuse controls) excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills `changelog.mdx` with weekly entries for June 24–August 18, 2026. The changelog was stale after June 23; it now lists 30 user-facing features with correct dates, tags, and doc links.

- Dates follow the weekly Tuesday cadence based on dev-merge week; relands are dated at re-land.
- Verify tags and titles per entry; “Issues & Topics” is marked early access.
- Spot-check links resolve (e.g., Bland, Amelia, Retell/Vapi, Pipecat, Slack, Metrics Library, Uptime, Trace v2, Deep Reports).
- Confirm branding/protocol names are correct (Bland, Amelia, Twilio, Vapi, Retell, LiveKit, Pipecat, CHIRP) and internal-only items remain excluded.
- Ensure MDX compiles (frontmatter intact, Update components render); no product/runtime behavior changes.

<sup>Written for commit 4675614e7b24074158e91911426c8e9156f3002d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

