### PR TITLE
docs: stop splitting alerts onto Custom Metrics only

### DIFF
--- a/api-reference/endpoint/list-issues.mdx
+++ b/api-reference/endpoint/list-issues.mdx
@@ -53,8 +53,8 @@ Then implement the integration, export it, and confirm it compiles/passes lint.
 </div>
 
 
-An issue is a problem found across your calls, such as the agent ending a call without confirming the outcome. This endpoint returns only issues that have a title. One-off failures that have not yet grouped are not included.
+An issue is a problem found across your calls, such as the agent ending a call without confirming the outcome. One-off failures that have not yet grouped are not included.
 
-Bluejay finds issues two ways. A `non_deterministic` issue (Pattern in the dashboard) is grouped from similar failures. It appears once the same problem recurs across calls, and only once it has a title. A `deterministic` issue (Error in the dashboard) comes from an error the platform recognizes outright, such as a tool call returning a 500, and appears as soon as that error is found.
+Bluejay finds issues two ways. A `non_deterministic` issue (Pattern in the dashboard) is grouped from similar failures. It appears once the same problem recurs across calls. A `deterministic` issue (Error in the dashboard) comes from an error the platform recognizes outright, such as a tool call returning a 500, and appears as soon as that error is found.
 
 Filter by `status`, `priority`, `type` or `assignee_id`. Results are ordered by when the issue was last seen, newest first. Pass `limit` (1 to 200, default 50) and `offset` to walk the list. The dashboard Issues page is not paginated. This list is.

--- a/key-concepts/issues/overview.mdx
+++ b/key-concepts/issues/overview.mdx
@@ -10,7 +10,7 @@ Issues group what went wrong on production calls so you can own a pattern instea
 
 Each evaluated production call is scored and checked for failures. Failures become Issues.
 
-Issues collect those failures so you can assign, prioritize, and close them. [Alerts](/key-concepts/alerts/overview) notify you when something you care about crosses a threshold.
+Issues collect those failures so you can assign, prioritize, and close them.
 
 ## How Issues appear
 
@@ -51,9 +51,6 @@ The title and the calls attached to an issue are produced by Bluejay. You cannot
   </Card>
   <Card title="Observability" icon="eye" href="/monitor/observability/overview">
     How production calls get into Bluejay.
-  </Card>
-  <Card title="Alerts" icon="bell" href="/key-concepts/alerts/overview">
-    Notifications when something you care about crosses a threshold.
   </Card>
   <Card title="Custom Metrics" icon="gauge-high" href="/key-concepts/custom-metrics/overview">
     The scores from evaluated calls.

--- a/key-concepts/issues/overview.mdx
+++ b/key-concepts/issues/overview.mdx
@@ -1,47 +1,18 @@
 ---
 title: Overview
-description: Understand how Issues group recurring production failures
+description: Own a production problem, see how often it happens, and triage it
 icon: triangle-exclamation
 ---
 
-Issues group what went wrong on production calls so you can own a pattern instead of hunting through logs. They are built from [observability](/monitor/observability/overview) evaluations. Open **Monitor → Issues**.
+Open **Monitor → Issues** to own a production problem, see how often it happens, and triage it.
 
-## Where Issues sit
+Failures on evaluated production calls become Issues. Each issue has a title and the calls it covers. Bluejay produces those. You cannot edit them.
 
-Each evaluated production call is scored and checked for failures. Failures become Issues.
-
-Issues collect those failures so you can assign, prioritize, and close them.
-
-## How Issues appear
-
-Bluejay finds issues two ways. The list labels them **Pattern** and **Error**.
-
-```mermaid
-flowchart LR
-    Call[Call evaluated] --> Fail{Failure found?}
-    Fail -->|No| Skip[Nothing listed]
-    Fail -->|Known error| Error[Error appears now]
-    Fail -->|Similar problem| Recur{Recurring?}
-    Recur -->|One-off| Hidden[Not listed]
-    Recur -->|Yes| Pattern[Pattern appears]
-```
-
-| Kind | When it shows | Example |
-|------|----------------|---------|
-| **Pattern** | Once the same problem recurs across calls | The agent ends the call without confirming the outcome |
-| **Error** | As soon as Bluejay recognizes a known failure | A tool returns a 500, or a tool that should have run never does |
-
-A one-off Pattern does not appear. That is expected.
-
-If a new failure matches an issue you already have, the calls join that issue. An issue that goes quiet stays on the list. Last Seen tells you how recently it happened.
-
-Errors often come from [tool calls](/monitor/observability/tool-calls) sent with the [evaluate](/api-reference/endpoint/evaluate) request.
+The list tags each issue as a **Pattern** (a recurring problem) or an **Error** (a known failure).
 
 ## What you can change
 
-Set status, priority, assignee, and due date. Status is Open, In Progress, Resolved, or Ignored. Priority stays empty until someone sets it.
-
-The title and the calls attached to an issue are produced by Bluejay. You cannot edit them.
+Set assignee, priority, due date, and status. Status is Open, In Progress, Resolved, or Ignored. Priority stays empty until someone sets it.
 
 ## Resources
 
@@ -51,18 +22,6 @@ The title and the calls attached to an issue are produced by Bluejay. You cannot
   </Card>
   <Card title="Observability" icon="eye" href="/monitor/observability/overview">
     How production calls get into Bluejay.
-  </Card>
-  <Card title="Custom Metrics" icon="gauge-high" href="/key-concepts/custom-metrics/overview">
-    The scores from evaluated calls.
-  </Card>
-  <Card title="Tool Calls" icon="wrench" href="/monitor/observability/tool-calls">
-    Include tool data so Errors like a 500 can be recognized.
-  </Card>
-  <Card title="Traces" icon="route" href="/key-concepts/traces/overview">
-    Send OpenTelemetry traces with production calls.
-  </Card>
-  <Card title="Webhooks" icon="bolt" href="/key-concepts/webhooks/overview">
-    Ingest calls and receive evaluation events.
   </Card>
   <Card title="List Issues API" icon="code" href="/api-reference/endpoint/list-issues">
     List, filter, and page issues. Newest last-seen first.

--- a/key-concepts/issues/overview.mdx
+++ b/key-concepts/issues/overview.mdx
@@ -23,15 +23,15 @@ flowchart LR
     Fail -->|Known error| Error[Error appears now]
     Fail -->|Similar problem| Recur{Recurring?}
     Recur -->|One-off| Hidden[Not listed]
-    Recur -->|Yes| Pattern[Pattern appears with a title]
+    Recur -->|Yes| Pattern[Pattern appears]
 ```
 
 | Kind | When it shows | Example |
 |------|----------------|---------|
-| **Pattern** | Once the same problem recurs across calls, and only once it has a title | The agent ends the call without confirming the outcome |
+| **Pattern** | Once the same problem recurs across calls | The agent ends the call without confirming the outcome |
 | **Error** | As soon as Bluejay recognizes a known failure | A tool returns a 500, or a tool that should have run never does |
 
-A one-off Pattern does not appear. That is expected. Until it has a title, it is not listed anywhere, including the API.
+A one-off Pattern does not appear. That is expected.
 
 If a new failure matches an issue you already have, the calls join that issue. An issue that goes quiet stays on the list. Last Seen tells you how recently it happened.
 

--- a/key-concepts/issues/overview.mdx
+++ b/key-concepts/issues/overview.mdx
@@ -8,17 +8,9 @@ Issues group what went wrong on production calls so you can own a pattern instea
 
 ## Where Issues sit
 
-Each evaluated production call is scored and checked for failures. [Custom Metrics](/key-concepts/custom-metrics/overview) feed [alerts](/key-concepts/alerts/overview). Failures feed Issues.
+Each evaluated production call is scored and checked for failures. Failures become Issues.
 
-```mermaid
-flowchart LR
-    Call[Production call evaluated] --> Metrics[Custom Metrics]
-    Call --> Failures[Failures]
-    Metrics --> Alert[Alerts]
-    Failures --> Issue[Issues]
-```
-
-Alerts notify you when a metric crosses a threshold. Issues collect the failures themselves so you can assign, prioritize, and close them.
+Issues collect those failures so you can assign, prioritize, and close them. [Alerts](/key-concepts/alerts/overview) notify you when something you care about crosses a threshold.
 
 ## How Issues appear
 
@@ -61,10 +53,10 @@ The title and the calls attached to an issue are produced by Bluejay. You cannot
     How production calls get into Bluejay.
   </Card>
   <Card title="Alerts" icon="bell" href="/key-concepts/alerts/overview">
-    Threshold notifications when a metric crosses a boundary.
+    Notifications when something you care about crosses a threshold.
   </Card>
   <Card title="Custom Metrics" icon="gauge-high" href="/key-concepts/custom-metrics/overview">
-    The scores that power alerts.
+    The scores from evaluated calls.
   </Card>
   <Card title="Tool Calls" icon="wrench" href="/monitor/observability/tool-calls">
     Include tool data so Errors like a 500 can be recognized.

--- a/monitor/observability/issues.mdx
+++ b/monitor/observability/issues.mdx
@@ -6,7 +6,7 @@ icon: triangle-exclamation
 
 Open **Monitor → Issues** to own a pattern instead of hunting through logs. What Issues are, and how Pattern vs Error works, is in [Issues Overview](/key-concepts/issues/overview).
 
-The page lists every issue that has a title. It is not paginated. Rows are grouped under Open, In Progress, Resolved, and Ignored. The count on each header is the full filtered set. Collapsing a section hides its rows.
+The page lists every issue. It is not paginated. Rows are grouped under Open, In Progress, Resolved, and Ignored. The count on each header is the full filtered set. Collapsing a section hides its rows.
 
 ## Filters
 

--- a/monitor/observability/issues.mdx
+++ b/monitor/observability/issues.mdx
@@ -1,16 +1,16 @@
 ---
 title: 'Issues'
-description: 'Triage recurring production failures from Monitor → Issues'
+description: 'Triage production problems from Monitor → Issues'
 icon: triangle-exclamation
 ---
 
-Open **Monitor → Issues** to own a pattern instead of hunting through logs. What Issues are, and how Pattern vs Error works, is in [Issues Overview](/key-concepts/issues/overview).
+Open **Monitor → Issues** to take a problem, see how often it happens, and work it. What you can change is in [Issues Overview](/key-concepts/issues/overview).
 
-The page lists every issue. It is not paginated. Rows are grouped under Open, In Progress, Resolved, and Ignored. The count on each header is the full filtered set. Collapsing a section hides its rows.
+The list is every issue. Rows are grouped under Open, In Progress, Resolved, and Ignored. The count on each header is the full filtered set. Collapsing a section hides its rows. Count and share cover the last 90 days.
 
 ## Filters
 
-Search, agent, Pattern vs Error, source, and status. The list is the full filtered set, not a page of results.
+Search, agent, Pattern vs Error, source, and status.
 
 ## Triage
 
@@ -24,7 +24,7 @@ The same issues are available over the API. List results are newest last-seen fi
 
 <CardGroup cols={2}>
   <Card title="Issues Overview" icon="triangle-exclamation" href="/key-concepts/issues/overview">
-    What Issues are, and how Pattern vs Error works.
+    What Issues is for, and what you can change.
   </Card>
   <Card title="List Issues" icon="list" href="/api-reference/endpoint/list-issues">
     List issues. Filter by status, priority, type, or assignee.

--- a/monitor/observability/issues.mdx
+++ b/monitor/observability/issues.mdx
@@ -24,7 +24,7 @@ The same issues are available over the API. List results are newest last-seen fi
 
 <CardGroup cols={2}>
   <Card title="Issues Overview" icon="triangle-exclamation" href="/key-concepts/issues/overview">
-    What Issues are, Pattern vs Error, and how they differ from Alerts.
+    What Issues are, and how Pattern vs Error works.
   </Card>
   <Card title="List Issues" icon="list" href="/api-reference/endpoint/list-issues">
     List issues. Filter by status, priority, type, or assignee.


### PR DESCRIPTION
- Drop the claim that Custom Metrics feed alerts and Failures feed Issues.
- Drop the diagram that hard-codes that split.
- Drop Alerts from the Issues overview and Monitor Issues pages. Issues do not have alerts yet.
- Drop the “until it has a title” framing from Pattern appearance copy.
- Rewrite the Issues overview around what the customer does on the page. Drop one-off and hiding copy.