### PR TITLE
[ENG-647] document branch and PR conventions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Branch and PR conventions
+
+Work starts from a Linear ticket in the Engineering team (ENG-...). Branch off `dev` (or `main` if this repo has no `dev`) and name the branch `kk-ENG-(ticket #)-(descriptive_feature_name)`.
+
+PR title: `[ENG-(ticket #)] (fix if it's a fix) (title)`.
+
+PR body is exactly four sections, 2-3 sentences each, hard cap:
+
+- Background: what exists today and what prompted the change.
+- Why: how this is a customer need.
+- What: summary of the change.
+- Notable: what a reviewer would otherwise miss.
+
+Cut anything that does not change how someone reviews or merges it. Minimal formatting, no bold or italics, bullets only for real lists.


### PR DESCRIPTION
## Background

Each repo's CLAUDE.md documents architecture, but none of them carried the branch or PR conventions. Those live only in the shared multirepo CLAUDE.md, which is not loaded when someone opens a single repo.

## Why

Inconsistent branch names and PR bodies slow down review and make it hard to trace a change back to its Linear ticket, which is what customers' issues are tracked against.

## What

Adds a "Branch and PR conventions" section to this repo's CLAUDE.md: the `kk-ENG-(ticket #)-(descriptive_feature_name)` branch name, the `[ENG-(ticket #)] (title)` PR title, and the Background / Why / What / Notable body at 2-3 sentences per section.

## Notable

Docs only, no code changes. bluejay_frontend_v2 and bluejay_middleware also get a note that a feature has to be mirrored across the UI, the public /v1 API, both MCPs, and Bluejay-as-Code, since those are separate write surfaces that drift apart.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds branch and PR conventions to this repo's `CLAUDE.md` so they're available when working in a single repo, instead of only in the shared multirepo `CLAUDE.md`.

- Documents the `kk-ENG-(ticket #)-(descriptive_feature_name)` branch naming and `[ENG-(ticket #)] (fix if it's a fix) (title)` PR title format.
- Specifies the four-section PR body (Background / Why / What / Notable) with 2-3 sentences per section and a hard cap.
- Docs only; no code changes.

<sup>Written for commit 34f570f8df520f6a8e721b768f31aa718c9d9df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

