### PR TITLE
[ENG-647] simplify CLAUDE.md PR conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,17 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Branch and PR conventions
-
-Work starts from a Linear ticket in the Engineering team (ENG-...). Branch off `dev` (or `main` if this repo has no `dev`) and name the branch `kk-ENG-(ticket #)-(descriptive_feature_name)`.
+## PR conventions
 
 PR title: `[ENG-(ticket #)] (fix if it's a fix) (title)`.
 
-PR body is exactly four sections, 2-3 sentences each, hard cap:
+PR body is four sections, 2-3 sentences each:
 
 - Background: what exists today and what prompted the change.
 - Why: how this is a customer need.
 - What: summary of the change.
 - Notable: what a reviewer would otherwise miss.
-
-Cut anything that does not change how someone reviews or merges it. Minimal formatting, no bold or italics, bullets only for real lists.


### PR DESCRIPTION
## Background

ENG-647 added a branch and PR conventions section to every repo's CLAUDE.md. The branch naming half duplicates what the shared multirepo CLAUDE.md already owns, and the section came out longer than it needs to be.

## Why

CLAUDE.md is loaded into every agent's context in this repo, so anything in it that does not change behavior is pure cost on every task.

## What

Drops the branch naming rules and trims the rest to the PR title format and the four body sections.

## Notable

Docs only. bluejay_frontend_v2 and bluejay_middleware keep the four-surfaces note (UI, /v1 API, both MCPs, Bluejay-as-Code), also shortened.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trims the PR conventions section in `CLAUDE.md` so agent context no longer carries redundant instructions.

- Removes branch naming rules, which duplicate the shared multirepo `CLAUDE.md`.
- Shortens the PR body guidance to the title format and four sections, dropping the formatting and length caps.
- Keeps the shortened four-surfaces note in `bluejay_frontend_v2` and `bluejay_middleware`.

<sup>Written for commit 843914782233465f7e1d230e0491de6f7abeead1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/docs/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

